### PR TITLE
Retry request to Rise Cache

### DIFF
--- a/rise-storage.html
+++ b/rise-storage.html
@@ -224,9 +224,9 @@
      *
      * @property _baseCacheUrl
      * @type string
-     * @default "//localhost:9494/files/"
+     * @default "//localhost:9494"
      */
-    _baseCacheUrl: "//localhost:9494/files/",
+    _baseCacheUrl: "//localhost:9494",
 
     /**
      * Whether or not Rise Cache V2 is running.
@@ -730,7 +730,7 @@
               if (self._isLoading) {
                 // Construct URL.
                 if (self._isCacheRunning) {
-                  file.url = self._baseCacheUrl + "?url=" + encodeURIComponent(item.selfLink + suffix);
+                  file.url = self._baseCacheUrl + "/files/?url=" + encodeURIComponent(item.selfLink + suffix);
                 }
                 else if(!self._isOfflinePlayer()) {
                   file.url = item.selfLink + suffix;
@@ -750,7 +750,7 @@
               else {
                 // Construct URL.
                 if (self._isCacheRunning) {
-                  file.url = self._baseCacheUrl + "cb=" + new Date().getTime() + "?url=" + encodeURIComponent(item.selfLink + suffix);
+                  file.url = self._baseCacheUrl + "/files/cb=" + new Date().getTime() + "?url=" + encodeURIComponent(item.selfLink + suffix);
                 }
                 else if(!self._isOfflinePlayer()) {
                   file.url = item.selfLink + suffix + cb;
@@ -832,12 +832,12 @@
       this._hasAttemptedGetRequest = false;
 
       if (this._isLoading) {
-        this._cacheUrl = this._baseCacheUrl + "?url=" + this._fileUrl;
+        this._cacheUrl = this._baseCacheUrl + "/files/?url=" + this._fileUrl;
       }
       else {
         // Include a cache buster as this will be the URL that gets passed to the browser
         // if the file has changed.
-        this._cacheUrl = this._baseCacheUrl + "cb=" + new Date().getTime() + "?url=" + this._fileUrl;
+        this._cacheUrl = this._baseCacheUrl + "/files/cb=" + new Date().getTime() + "?url=" + this._fileUrl;
       }
 
       this.$.cache.generateRequest();
@@ -896,7 +896,7 @@
       this._hasAttemptedGetRequest = false;
 
       this._setFileUrl(item);
-      this._cacheUrl = this._baseCacheUrl + "cb=" + new Date().getTime() + "?url=" + this._fileUrl;
+      this._cacheUrl = this._baseCacheUrl + "/files/cb=" + new Date().getTime() + "?url=" + this._fileUrl;
       this.$.cache.generateRequest();
     },
 

--- a/rise-storage.html
+++ b/rise-storage.html
@@ -939,6 +939,8 @@
         } else {
           lastModified = resp.xhr.getResponseHeader("Last-Modified");
           file.url = resp.xhr.responseURL;
+          this._totalCacheRequests = 0;
+
           // Fallback to browsers that does not support responseURL.
           if(!file.url){
             file.url = resp.xhr.getResponseHeader("Location");

--- a/rise-storage.html
+++ b/rise-storage.html
@@ -17,7 +17,7 @@
     <iron-ajax id="cache"
                method="{{_cacheRequestMethod}}"
                url="{{_cacheUrl}}"
-               handle-as="text"
+               handle-as="json"
                on-response="_handleCacheResponse"
                on-error="_handleCacheError"
                verbose="true">

--- a/rise-storage.html
+++ b/rise-storage.html
@@ -14,6 +14,15 @@
                verbose="true">
     </iron-ajax>
 
+    <iron-ajax id="cache"
+               method="{{_cacheRequestMethod}}"
+               url="{{_cacheUrl}}"
+               handle-as="text"
+               on-response="_handleCacheResponse"
+               on-error="_handleCacheError"
+               verbose="true">
+    </iron-ajax>
+
     <iron-ajax id="storage"
       handle-as="json"
       on-response="_handleStorageResponse"
@@ -26,15 +35,6 @@
        on-response="_handleStorageSubscriptionResponse"
        on-error="_handleStorageSubscriptionError"
        verbose="true">
-    </iron-ajax>
-
-    <iron-ajax id="cache"
-      method="{{_cacheRequestMethod}}"
-      url="{{_cacheUrl}}"
-      handle-as="text"
-      on-response="_handleCacheResponse"
-      on-error="_handleCacheError"
-      verbose="true">
     </iron-ajax>
 
   </template>
@@ -174,6 +174,15 @@
      */
     _cacheRequestMethod: "HEAD",
 
+      /**
+     * The total number of requests made to Rise Cache.
+     *
+     * @property _totalCacheRequests
+     * @type number
+     * @default 0
+     */
+    _totalCacheRequests: 0,
+
     /**
      * The flag for making a get request if it wasn't done yet.
      *
@@ -215,9 +224,9 @@
      *
      * @property _baseCacheUrl
      * @type string
-     * @default "//localhost:9494/"
+     * @default "//localhost:9494/files/"
      */
-    _baseCacheUrl: "//localhost:9494/",
+    _baseCacheUrl: "//localhost:9494/files/",
 
     /**
      * Whether or not Rise Cache V2 is running.
@@ -918,45 +927,56 @@
         lastModified = "";
 
       if (resp && resp.xhr) {
-        lastModified = resp.xhr.getResponseHeader("Last-Modified");
-        file.url = resp.xhr.responseURL;
-        // Fallback to browsers that does not support responseURL.
-        if(!file.url){
-          file.url = resp.xhr.getResponseHeader("Location");
-        }
-        if(!file.url){
-          file.url = this._cacheUrl;
-        }
+        if (resp.xhr.status === 202) {
+          this._totalCacheRequests++;
 
-        if (this._isLoading) {
-          // Save Last Modified so it can be compared in subsequent requests.
-          this._files.push({
-            "name": this._getFileNameFromUrl(file.url),
-            "lastModified": lastModified
-          });
-
-          file.added = true;
-
-          if (lastModified === null) {
-            console.log("File does not have a Last-Modified header: " + file.url);
+          // Retry cache request a maximum of 3 times.
+          if (this._totalCacheRequests < 3) {
+            this._retryCacheRequest();
+          } else {
+            this.fire("rise-cache-file-unavailable", resp);
+          }
+        } else {
+          lastModified = resp.xhr.getResponseHeader("Last-Modified");
+          file.url = resp.xhr.responseURL;
+          // Fallback to browsers that does not support responseURL.
+          if(!file.url){
+            file.url = resp.xhr.getResponseHeader("Location");
+          }
+          if(!file.url){
+            file.url = this._cacheUrl;
           }
 
-          this._isLoading = false;
-        }
-        else {
-          // Rise Cache file hasn't changed.
-          if (this._files[0].lastModified === lastModified) {
-            file.changed = false;
+          if (this._isLoading) {
+            // Save Last Modified so it can be compared in subsequent requests.
+            this._files.push({
+              "name": this._getFileNameFromUrl(file.url),
+              "lastModified": lastModified
+            });
+
+            file.added = true;
+
+            if (lastModified === null) {
+              console.log("File does not have a Last-Modified header: " + file.url);
+            }
+
+            this._isLoading = false;
           }
           else {
-            this._files[0].lastModified = lastModified;
-            file.changed = true;
+            // Rise Cache file hasn't changed.
+            if (this._files[0].lastModified === lastModified) {
+              file.changed = false;
+            }
+            else {
+              this._files[0].lastModified = lastModified;
+              file.changed = true;
+            }
           }
+
+          file.name = this._getFileNameFromUrl(file.url);
+
+          this.fire("rise-storage-response", file);
         }
-
-        file.name = this._getFileNameFromUrl(file.url);
-
-        this.fire("rise-storage-response", file);
       }
 
       this._startTimer();
@@ -1148,6 +1168,15 @@
           this.$.ping.generateRequest();
         }, this.refresh * 60000);
       }
+    },
+
+    /**
+     * Retries a request to Rise Cache.
+     */
+    _retryCacheRequest: function() {
+      this.debounce("cache", function() {
+        this.$.cache.generateRequest();
+      }, 3000);
     },
 
     /**
@@ -1434,6 +1463,7 @@
       this._numFiles = 0;
       this._totalFiles = 0;
       this._cacheRequestMethod = "HEAD";
+      this._totalCacheRequests = 0;
       this._hasAttemptedGetRequest = false;
       this._folderFilesToRequest = [];
       this._folderFilesRequested = 0;

--- a/test/integration/rise-cache.html
+++ b/test/integration/rise-cache.html
@@ -34,8 +34,12 @@
       setup(function () {
         server = sinon.fakeServer.create();
         server.respondImmediately = true;
+
+        // Ping request
         server.respondWith("GET", "http://localhost:9494/ping?callback=_handlePingResponse",
           [200, cacheHeader, "running"]);
+
+        // Storage request
         server.respondWith("GET", "https://store-dot-rvaserver2.appspot.com/v1/widget/auth?cid=abc123&pc=b0cba08a4baa0c62b8cdc621b6f6a124f89a03db",
           [200, header, JSON.stringify(subscribedStatus)]);
 
@@ -173,6 +177,53 @@
 
           cacheFileFolder.addEventListener("rise-storage-file-throttled", responseHandler);
           server.respondWith([200, header, JSON.stringify(folderImage)]);
+          cacheFileFolder.go();
+        });
+
+      });
+
+      suite("cache requests", function() {
+        var spy;
+
+        setup(function () {
+          spy = sinon.spy(cacheFileFolder.$.cache, "generateRequest");
+
+          // Rise Cache request
+          server.respondWith("HEAD", /localhost/,
+            [202, header, JSON.stringify({ status: 202, message: "File is downloading" })]);
+          server.respondWith([200, header, JSON.stringify(folderImage)]);
+
+          clock.restore();
+        });
+
+        teardown(function() {
+          spy.restore();
+          clock.restore();
+        });
+
+        test("should fire 'rise-cache-file-unavailable' after 3 retries", function(done) {
+          responseHandler = function(response) {
+            assert(spy.calledThrice);
+
+            cacheFileFolder.removeEventListener("rise-cache-file-unavailable", responseHandler);
+            done();
+          };
+
+          // Delay this call until the cache retry timer has been set.
+          setTimeout(function() {
+            clock.tick(3000);
+            clock.restore(); // Need to set a real timeout.
+
+            // Retry timer has expired. Wait for next one to be set before expiring it as well.
+            setTimeout(function() {
+              clock.tick(3000);
+            }, 0);
+
+            clock = sinon.useFakeTimers();
+          }, 0);
+
+          clock = sinon.useFakeTimers();
+          cacheFileFolder.addEventListener("rise-cache-file-unavailable", responseHandler);
           cacheFileFolder.go();
         });
 

--- a/test/integration/rise-cache.html
+++ b/test/integration/rise-cache.html
@@ -24,10 +24,10 @@
         responseHandler,
         cacheFile = document.querySelector("#cache-file"),
         cacheFileFolder = document.querySelector("#cache-file-folder"),
-        cacheHeader = { "Last-Modified": "Fri, 01 May 2015 15:32:11 GMT", "Location": "//localhost:9494/?url=https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fhome.jpg" },
-        cacheHeaderFolder = { "Last-Modified": "Fri, 01 May 2015 15:32:11 GMT", "Location": "//localhost:9494/?url=https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fimages%252Fhome.jpg" },
-        newCacheHeader = { "Last-Modified": "Fri, 24 Apr 2015 15:32:11 GMT", "Location": "//localhost:9494/cb=0?url=https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fhome.jpg" };
-        newCacheHeaderFolder = { "Last-Modified": "Fri, 24 Apr 2015 15:32:11 GMT", "Location": "//localhost:9494/cb=0?url=https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fimages%252Fhome.jpg" };
+        cacheHeader = { "Last-Modified": "Fri, 01 May 2015 15:32:11 GMT", "Location": "//localhost:9494/files/?url=https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fhome.jpg" },
+        cacheHeaderFolder = { "Last-Modified": "Fri, 01 May 2015 15:32:11 GMT", "Location": "//localhost:9494/files/?url=https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fimages%252Fhome.jpg" },
+        newCacheHeader = { "Last-Modified": "Fri, 24 Apr 2015 15:32:11 GMT", "Location": "//localhost:9494/files/cb=0?url=https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fhome.jpg" };
+        newCacheHeaderFolder = { "Last-Modified": "Fri, 24 Apr 2015 15:32:11 GMT", "Location": "//localhost:9494/files/cb=0?url=https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fimages%252Fhome.jpg" };
 
 
       // Runs for every test
@@ -62,7 +62,7 @@
         test("should return the correct URL for a specific file in a bucket", function(done) {
           responseHandler = function(response) {
             assert.equal(response.detail.name, "home.jpg");
-            assert.equal(response.detail.url, "//localhost:9494/?url=https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fhome.jpg");
+            assert.equal(response.detail.url, "//localhost:9494/files/?url=https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fhome.jpg");
             done();
           };
 
@@ -86,7 +86,7 @@
           responseHandler = function(response) {
             assert.isTrue(response.detail.changed);
             assert.equal(response.detail.name, "home.jpg");
-            assert.equal(response.detail.url, "//localhost:9494/cb=0?url=https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fhome.jpg");
+            assert.equal(response.detail.url, "//localhost:9494/files/cb=0?url=https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fhome.jpg");
             done();
           };
 
@@ -112,7 +112,7 @@
           responseHandler = function(response) {
             assert.isTrue(response.detail.added);
             assert.equal(response.detail.name, "images%2Fhome.jpg");
-            assert.equal(response.detail.url, "//localhost:9494/?url=https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fimages%252Fhome.jpg");
+            assert.equal(response.detail.url, "//localhost:9494/files/?url=https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fimages%252Fhome.jpg");
             done();
           };
 
@@ -136,7 +136,7 @@
           responseHandler = function(response) {
             assert.isTrue(response.detail.changed);
             assert.equal(response.detail.name, "images%2Fhome.jpg");
-            assert.equal(response.detail.url, "//localhost:9494/cb=0?url=https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fimages%252Fhome.jpg");
+            assert.equal(response.detail.url, "//localhost:9494/files/cb=0?url=https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fimages%252Fhome.jpg");
             done();
           };
 

--- a/test/js/rise-storage-data.js
+++ b/test/js/rise-storage-data.js
@@ -1,4 +1,4 @@
-var header = { "Content-Type": "text/json" },
+var header = { "Content-Type": "application/json" },
   images = {
     "result": true,
     "code": 200,

--- a/test/unit/rise-cache.html
+++ b/test/unit/rise-cache.html
@@ -72,9 +72,9 @@
             assert.equal(files[0].name, "images%2Fhome.jpg");
             assert.equal(files[1].name, "images%2Fcircle.png");
             assert.equal(files[2].name, "images%2Fmy-image.bmp");
-            assert.equal(files[0].url, "//localhost:9494/?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fhome.jpg%3Falt%3Dmedia");
-            assert.equal(files[1].url, "//localhost:9494/?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fcircle.png%3Falt%3Dmedia");
-            assert.equal(files[2].url, "//localhost:9494/?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fmy-image.bmp%3Falt%3Dmedia");
+            assert.equal(files[0].url, "//localhost:9494/files/?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fhome.jpg%3Falt%3Dmedia");
+            assert.equal(files[1].url, "//localhost:9494/files/?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fcircle.png%3Falt%3Dmedia");
+            assert.equal(files[2].url, "//localhost:9494/files/?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fmy-image.bmp%3Falt%3Dmedia");
           }
         };
 
@@ -100,7 +100,7 @@
           if (response.detail.changed) {
             responded = true;
             assert.equal(response.detail.name, "images%2Fcircle.png");
-            assert.equal(response.detail.url, "//localhost:9494/cb=0?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fcircle.png%3Falt%3Dmedia");
+            assert.equal(response.detail.url, "//localhost:9494/files/cb=0?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fcircle.png%3Falt%3Dmedia");
           }
         };
 
@@ -117,7 +117,7 @@
           if (response.detail.added) {
             responded = true;
             assert.equal(response.detail.name, "images%2Fgolf.svg");
-            assert.equal(response.detail.url, "//localhost:9494/cb=0?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fgolf.svg%3Falt%3Dmedia");
+            assert.equal(response.detail.url, "//localhost:9494/files/cb=0?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fgolf.svg%3Falt%3Dmedia");
           }
         };
 
@@ -140,7 +140,7 @@
           if (response.detail.deleted) {
             responded = true;
             assert.equal(response.detail.name, "images%2Fgolf.svg");
-            assert.equal(response.detail.url, "//localhost:9494/cb=0?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fgolf.svg%3Falt%3Dmedia");
+            assert.equal(response.detail.url, "//localhost:9494/files/cb=0?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fgolf.svg%3Falt%3Dmedia");
             cacheFolder.removeEventListener("rise-storage-response", listener);
           }
         };
@@ -173,13 +173,13 @@
       test("should correctly set the cache URL when loading", function() {
         cacheFile._isLoading = true;
         cacheFile._getFileFromCache();
-        assert.equal(cacheFile._cacheUrl, "//localhost:9494/?url=http://url.to.my.file");
+        assert.equal(cacheFile._cacheUrl, "//localhost:9494/files/?url=http://url.to.my.file");
       });
 
       test("should correctly set the cache URL when not loading", function() {
         cacheFile._isLoading = false;
         cacheFile._getFileFromCache();
-        assert.equal(cacheFile._cacheUrl, "//localhost:9494/cb=0?url=http://url.to.my.file");
+        assert.equal(cacheFile._cacheUrl, "//localhost:9494/files/cb=0?url=http://url.to.my.file");
       });
     });
 
@@ -237,7 +237,7 @@
     suite("_handleCacheFile", function() {
 
       test("should get the file url from the xhr.responseURL", function(done) {
-        var url = "//localhost:9494/cb=0?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fgolf.svg%3Falt%3Dmedia";
+        var url = "//localhost:9494/files/cb=0?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fgolf.svg%3Falt%3Dmedia";
         var resp = {
           xhr: {
             responseURL: url,
@@ -255,7 +255,7 @@
           if (response.detail.added) {
             responded = true;
             assert.equal(response.detail.name, "images%2Fgolf.svg");
-            assert.equal(response.detail.url, "//localhost:9494/cb=0?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fgolf.svg%3Falt%3Dmedia");
+            assert.equal(response.detail.url, "//localhost:9494/files/cb=0?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fgolf.svg%3Falt%3Dmedia");
             cacheFile.removeEventListener("rise-storage-response", listener);
           }
         };
@@ -269,7 +269,7 @@
       });
 
       test("should fallback to get the file url from the 'Location' header attribute", function(done) {
-        var url = "//localhost:9494/cb=0?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fgolf.svg%3Falt%3Dmedia";
+        var url = "//localhost:9494/files/cb=0?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fgolf.svg%3Falt%3Dmedia";
         var resp = {
           xhr: {
             getResponseHeader: function (attribute) {
@@ -286,7 +286,7 @@
           if (response.detail.added) {
             responded = true;
             assert.equal(response.detail.name, "images%2Fgolf.svg");
-            assert.equal(response.detail.url, "//localhost:9494/cb=0?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fgolf.svg%3Falt%3Dmedia");
+            assert.equal(response.detail.url, "//localhost:9494/files/cb=0?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fgolf.svg%3Falt%3Dmedia");
             cacheFile.removeEventListener("rise-storage-response", listener);
           }
         };
@@ -300,7 +300,7 @@
       });
 
       test("should get the file url from the this._cacheUrl", function(done) {
-        var url = "//localhost:9494/cb=0?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fgolf.svg%3Falt%3Dmedia";
+        var url = "//localhost:9494/files/cb=0?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fgolf.svg%3Falt%3Dmedia";
         var resp = {
           xhr: {
             responseURL: null,
@@ -318,7 +318,7 @@
           if (response.detail.added) {
             responded = true;
             assert.equal(response.detail.name, "images%2Fgolf.svg");
-            assert.equal(response.detail.url, "//localhost:9494/cb=0?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fgolf.svg%3Falt%3Dmedia");
+            assert.equal(response.detail.url, "//localhost:9494/files/cb=0?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fgolf.svg%3Falt%3Dmedia");
             cacheFile.removeEventListener("rise-storage-response", listener);
           }
         };
@@ -336,7 +336,7 @@
     suite("_handleCacheFolder", function() {
 
       test("should fallback to get the file url from the 'Location' header attribute", function(done) {
-        var url = "//localhost:9494/cb=0?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fgolf.svg%3Falt%3Dmedia";
+        var url = "//localhost:9494/files/cb=0?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fgolf.svg%3Falt%3Dmedia";
         var resp = {
           xhr: {
             getResponseHeader: function (attribute) {
@@ -353,7 +353,7 @@
           if (response.detail.added) {
             responded = true;
             assert.equal(response.detail.name, "images%2Fgolf.svg");
-            assert.equal(response.detail.url, "//localhost:9494/cb=0?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fgolf.svg%3Falt%3Dmedia");
+            assert.equal(response.detail.url, "//localhost:9494/files/cb=0?url=https%3A%2F%2Fwww.googleapis.com%2Fstorage%2Fv1%2Fb%2Frisemedialibrary-abc123%2Fo%2Fimages%252Fgolf.svg%3Falt%3Dmedia");
             cacheFolder.removeEventListener("rise-storage-response", listener);
           }
         };


### PR DESCRIPTION
* Retry request to Rise Cache a maximum of 3 times to check if the file has been downloaded before firing a `rise-cache-file-unavailable` event.
* Needed to use some `setTimeout` and `sinon.useFakeTimers` trickery to provide test coverage.