### PR TITLE
No refresh when Rise Cache is not running

### DIFF
--- a/rise-storage.html
+++ b/rise-storage.html
@@ -1159,6 +1159,11 @@
         return;
       }
 
+      // If Rise Cache is not running do not refresh
+      if (!this._isCacheRunning) {
+        return;
+      }
+
       this.refresh = parseInt(this.refresh, 10);
 
       if (!isNaN(this.refresh) && this.refresh !== 0) {

--- a/test/integration/offline-player.html
+++ b/test/integration/offline-player.html
@@ -19,16 +19,15 @@
       var clock,
         server,
         responseHandler,
-        offlinePlayer = document.querySelector("#offline-player"),
-        cacheHeader = { "Last-Modified": "Fri, 01 May 2015 15:32:11 GMT" };
+        offlinePlayer = document.querySelector("#offline-player");
 
       // Runs for every suite.
       suiteSetup(function() {
         server = sinon.fakeServer.create();
 
         // Send a response to the ping request.
-        server.respondWith("GET", "http://localhost:9494/ping?callback=_handlePingResponse",
-          [200, cacheHeader, ""]);
+        server.respondWith("GET", "http://localhost:9494",
+          [200, header, cachePingBody]);
 
         clock = sinon.useFakeTimers();
       });

--- a/test/integration/offline-player.html
+++ b/test/integration/offline-player.html
@@ -27,7 +27,7 @@
 
         // Send a response to the ping request.
         server.respondWith("GET", "http://localhost:9494",
-          [200, header, cachePingBody]);
+          [200, header, JSON.stringify(cachePingBody)]);
 
         clock = sinon.useFakeTimers();
       });

--- a/test/integration/rise-cache.html
+++ b/test/integration/rise-cache.html
@@ -36,8 +36,8 @@
         server.respondImmediately = true;
 
         // Ping request
-        server.respondWith("GET", "http://localhost:9494/ping?callback=_handlePingResponse",
-          [200, cacheHeader, "running"]);
+        server.respondWith("GET", "http://localhost:9494",
+          [200, header, cachePingBody]);
 
         // Storage request
         server.respondWith("GET", "https://store-dot-rvaserver2.appspot.com/v1/widget/auth?cid=abc123&pc=b0cba08a4baa0c62b8cdc621b6f6a124f89a03db",

--- a/test/integration/rise-cache.html
+++ b/test/integration/rise-cache.html
@@ -11,7 +11,7 @@
   <link rel="import" href="../../rise-storage.html">
 </head>
 <body>
-  <rise-storage id="cache-file" companyId="abc123" fileName="home.jpg"></rise-storage>
+  <rise-storage id="cache-file" companyId="abc123" fileName="home.jpg" refresh="5"></rise-storage>
   <rise-storage id="cache-file-folder" companyId="abc123" folder="images" fileName="home.jpg" refresh="5"></rise-storage>
 
   <script src="../js/rise-storage-data.js"></script>
@@ -37,7 +37,7 @@
 
         // Ping request
         server.respondWith("GET", "http://localhost:9494",
-          [200, header, cachePingBody]);
+          [200, header, JSON.stringify(cachePingBody)]);
 
         // Storage request
         server.respondWith("GET", "https://store-dot-rvaserver2.appspot.com/v1/widget/auth?cid=abc123&pc=b0cba08a4baa0c62b8cdc621b6f6a124f89a03db",
@@ -178,6 +178,40 @@
           cacheFileFolder.addEventListener("rise-storage-file-throttled", responseHandler);
           server.respondWith([200, header, JSON.stringify(folderImage)]);
           cacheFileFolder.go();
+        });
+
+      });
+
+      suite("rise-storage-api-error", function() {
+
+        suiteSetup(function () {
+          cacheFile._reset();
+          cacheFile._isCacheRunning = true;
+          cacheFile._pingReceived = true;
+          cacheFile._fileUrl = "https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fhome.jpg";
+        });
+
+        teardown(function() {
+          cacheFile.removeEventListener("rise-storage-api-error", responseHandler);
+        });
+
+        test("should retry storage request after rise-storage-api-error is encountered", function(done) {
+          var timerSpy;
+
+          responseHandler = function(response) {
+            timerSpy = sinon.spy(cacheFile.$.ping, "generateRequest");
+
+            clock.tick(299999);
+            assert(timerSpy.notCalled);
+            clock.tick(300000);
+            assert(timerSpy.calledOnce);
+
+            done();
+          };
+
+          cacheFile.addEventListener("rise-storage-api-error", responseHandler);
+          server.respondWith([200, header, JSON.stringify(apiError)]);
+          cacheFile.go();
         });
 
       });

--- a/test/integration/rise-storage.html
+++ b/test/integration/rise-storage.html
@@ -32,8 +32,7 @@
         fileFolder = document.querySelector("#file-folder"),
         fileType = document.querySelector("#file-type"),
         invalidFolder = document.querySelector("#folder-invalid"),
-        contentType = document.querySelector("#content-type"),
-        cacheHeader = { "Last-Modified": "Fri, 01 May 2015 15:32:11 GMT" };
+        contentType = document.querySelector("#content-type");
 
       // Runs for every test
       setup(function () {
@@ -41,8 +40,8 @@
 
         server = sinon.fakeServer.create();
         server.respondImmediately = true;
-        server.respondWith("GET", "http://localhost:9494/ping?callback=_handlePingResponse",
-          [200, cacheHeader, ""]);
+        server.respondWith("GET", "http://localhost:9494",
+          [200, header, JSON.stringify(cachePingBody)]);
         server.respondWith("GET", "https://store-dot-rvaserver2.appspot.com/v1/widget/auth?cid=abc123&pc=b0cba08a4baa0c62b8cdc621b6f6a124f89a03db",
           [200, header, JSON.stringify(subscribedStatus)]);
       });
@@ -354,25 +353,6 @@
           done();
         });
 
-        test("should retry storage request after rise-storage-api-error is encountered", function(done) {
-          var timerSpy;
-
-          responseHandler = function(response) {
-            timerSpy = sinon.spy(file.$.ping, "generateRequest");
-
-            clock.tick(299999);
-            assert(timerSpy.notCalled);
-            clock.tick(300000);
-            assert(timerSpy.calledOnce);
-
-            done();
-          };
-
-          file.addEventListener("rise-storage-api-error", responseHandler);
-          server.respondWith([200, header, JSON.stringify(apiError)]);
-          file.go();
-        });
-
       });
 
       suite("rise-storage-empty-folder", function() {
@@ -638,27 +618,6 @@
           };
 
           folderImage.files[0].isThrottled = true;
-
-          fileFolder.addEventListener("rise-storage-file-throttled", responseHandler);
-          server.respondWith([200, header, JSON.stringify(folderImage)]);
-          fileFolder.go();
-        });
-
-        test("should make a request to Storage after 5 minutes to check if a file is still throttled", function(done) {
-          var timerSpy;
-
-          responseHandler = function(response) {
-            timerSpy = sinon.spy(fileFolder.$.ping, "generateRequest");
-
-            clock.tick(299999);
-            assert(timerSpy.notCalled);
-            clock.tick(300000);
-            assert(timerSpy.calledOnce);
-
-            fileFolder.removeEventListener("rise-storage-file-throttled", responseHandler);
-
-            done();
-          };
 
           fileFolder.addEventListener("rise-storage-file-throttled", responseHandler);
           server.respondWith([200, header, JSON.stringify(folderImage)]);

--- a/test/js/rise-storage-data.js
+++ b/test/js/rise-storage-data.js
@@ -1,4 +1,8 @@
 var header = { "Content-Type": "application/json" },
+  cachePingBody = {
+    "name": "rise-cache-v2",
+    "version": "0.0.0"
+  },
   images = {
     "result": true,
     "code": 200,

--- a/test/unit/rise-cache.html
+++ b/test/unit/rise-cache.html
@@ -457,6 +457,10 @@
     suite("_startTimer", function() {
       var timerSpy;
 
+      teardown(function () {
+        if (timerSpy) { timerSpy.restore(); }
+      });
+
       test("should correctly set refresh interval", function() {
         cacheFolder.refresh = 10;
         cacheFolder._startTimer();
@@ -469,9 +473,21 @@
         assert.equal(cacheFolder.refresh, 5);
       });
 
+      test("should not execute any timer if Rise Cache is not running", function() {
+        timerSpy = sinon.spy(cacheFile.$.ping, "generateRequest");
+
+        cacheFile._isCacheRunning = false;
+        cacheFile.refresh = 5;
+        cacheFile._startTimer();
+
+        clock.tick(300000);
+        assert.equal(timerSpy.callCount, 0);
+      });
+
       test("should check for changes to a file", function() {
         timerSpy = sinon.spy(cacheFile.$.ping, "generateRequest");
 
+        cacheFile._isCacheRunning = true;
         cacheFile.refresh = 5;
         cacheFile._startTimer();
 


### PR DESCRIPTION
- Will only execute `startTimer` code if Rise Cache is running
- Unit tests added
- Revised and removed two integration tests that are no longer applicable