### PR TITLE
Make immediate request to RC for a file

### DIFF
--- a/rise-storage.html
+++ b/rise-storage.html
@@ -832,18 +832,9 @@
      * Makes a request to Rise Cache to retrieve a file.
      */
     _getFileFromCache: function() {
-
       this._cacheRequestMethod = "HEAD";
       this._hasAttemptedGetRequest = false;
-
-      if (this._isLoading) {
-        this._cacheUrl = this._baseCacheUrl + "/files/?url=" + this._fileUrl;
-      }
-      else {
-        // Include a cache buster as this will be the URL that gets passed to the browser
-        // if the file has changed.
-        this._cacheUrl = this._baseCacheUrl + "/files" + "?url=" + this._fileUrl;
-      }
+      this._cacheUrl = this._baseCacheUrl + "/files?url=" + this._fileUrl;
 
       this.$.cache.generateRequest();
     },
@@ -1152,7 +1143,29 @@
      */
     go: function() {
       if (this._pingReceived) {
-       this._getStorageSubscription();
+        if (!this._isCacheRunning) {
+          this._getStorageSubscription();
+        }
+        else {
+          // get file immediately from Rise Cache
+
+          if (this.companyid) {
+            if (this._isLoading) {
+              // determine if configured for a file
+              this._isFile = (this.filename !== "");
+            }
+
+            if (this._isFile) {
+              // configure the file path
+              this._fileUrl = encodeURIComponent("https://storage.googleapis.com/" + this._getStoragePath());
+
+              this._getFileFromCache();
+            }
+            else {
+              this._getStorageSubscription();
+            }
+          }
+        }
       }
     },
 

--- a/test/integration/rise-cache.html
+++ b/test/integration/rise-cache.html
@@ -161,7 +161,8 @@
           folderImage.files[0].isThrottled = false;
         });
 
-        test("should make a request to Storage after 5 minutes to check if a file is still throttled", function(done) {
+        // TODO: needs to be repurposed once handling failure is implemented
+        /*test("should make a request to Storage after 5 minutes to check if a file is still throttled", function(done) {
           responseHandler = function(response) {
             timerSpy = sinon.spy(cacheFileFolder.$.ping, "generateRequest");
 
@@ -178,7 +179,7 @@
           cacheFileFolder.addEventListener("rise-storage-file-throttled", responseHandler);
           server.respondWith([200, header, JSON.stringify(folderImage)]);
           cacheFileFolder.go();
-        });
+        });*/
 
       });
 
@@ -195,7 +196,8 @@
           cacheFile.removeEventListener("rise-storage-api-error", responseHandler);
         });
 
-        test("should retry storage request after rise-storage-api-error is encountered", function(done) {
+        // TODO: needs to be repurposed once handling failure is implemented
+        /*test("should retry storage request after rise-storage-api-error is encountered", function(done) {
           var timerSpy;
 
           responseHandler = function(response) {
@@ -212,7 +214,7 @@
           cacheFile.addEventListener("rise-storage-api-error", responseHandler);
           server.respondWith([200, header, JSON.stringify(apiError)]);
           cacheFile.go();
-        });
+        });*/
 
       });
 
@@ -259,6 +261,20 @@
           clock = sinon.useFakeTimers();
           cacheFileFolder.addEventListener("rise-cache-file-unavailable", responseHandler);
           cacheFileFolder.go();
+        });
+
+        test("should not make request if company id value is not set", function () {
+          cacheFileFolder.companyid = "";
+          cacheFileFolder.go();
+
+          assert(spy.notCalled);
+        });
+
+        test("should make immediate request for a file", function () {
+          cacheFileFolder.companyid = "abc123";
+          cacheFileFolder.go();
+
+          assert(spy.calledOnce);
         });
 
       });

--- a/test/unit/rise-cache.html
+++ b/test/unit/rise-cache.html
@@ -182,14 +182,8 @@
         assert.equal(cacheFile._hasAttemptedGetRequest, false);
       });
 
-      test("should correctly set the cache URL when loading", function() {
+      test("should correctly set the cache URL", function() {
         cacheFile._isLoading = true;
-        cacheFile._getFileFromCache();
-        assert.equal(cacheFile._cacheUrl, "//localhost:9494/files/?url=http://url.to.my.file");
-      });
-
-      test("should correctly set the cache URL when not loading", function() {
-        cacheFile._isLoading = false;
         cacheFile._getFileFromCache();
         assert.equal(cacheFile._cacheUrl, "//localhost:9494/files?url=http://url.to.my.file");
       });


### PR DESCRIPTION
- When RC is running, skip checking storage subscription and subsequent storage request, make the request for the file from RC immediately
- Tests revised, temporarily removed, and added