### PR TITLE
Only get Storage metadata if Rise Cache returns 502 or 534

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-storage",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "authors": [
     "Rise Vision"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-storage",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Rise Vision web component for retrieving files from Rise Storage",
   "scripts": {
     "test": "gulp test",

--- a/rise-storage.html
+++ b/rise-storage.html
@@ -1139,18 +1139,16 @@ To specify a direction, the `sortDirection` attribute should be used. `sortDirec
        * Fires when an error is received from the Rise Cache request.
        */
       _handleCacheError: function(e, resp) {
-        var isServerError = false;
-
         if ( !this._hasAttemptedGetRequest ) {
           this._cacheRequestMethod = "GET";
           this.$.cache.generateRequest();
           this._hasAttemptedGetRequest = true;
         }
         else {
-          isServerError = e.detail.request.xhr.response.status.toString()[0] === "5";
+          var status = e.detail.request.xhr.response.status;
 
           // Get metadata for single file on Rise Cache server error.
-          if (isServerError && this._isFile) {
+          if (((status === 502) || (status === 534)) && this._isFile) {
             this.getMetadata();
           } else {
             this._startTimer();

--- a/test/unit/rise-cache.html
+++ b/test/unit/rise-cache.html
@@ -437,9 +437,21 @@
         done();
       });
 
-      test("should go out to Rise Storage if there is a problem with the Rise Cache request for a file", function(done) {
+      test("should go out to Rise Storage if Rise Cache returns a 502", function(done) {
         var spy = sinon.spy(cacheFile, "getMetadata");
 
+        cacheFile._hasAttemptedGetRequest = true;
+        cacheFile._handleCacheError(event, resp);
+        assert.equal(spy.callCount, 1);
+        spy.restore();
+
+        done();
+      });
+
+      test("should go out to Rise Storage if Rise Cache returns a 534", function(done) {
+        var spy = sinon.spy(cacheFile, "getMetadata");
+
+        event.detail.request.xhr.response.status = 534;
         cacheFile._hasAttemptedGetRequest = true;
         cacheFile._handleCacheError(event, resp);
         assert.equal(spy.callCount, 1);


### PR DESCRIPTION
Fetch Storage metadata only if Rise Cache returns a 502 or 534. In other words, only fetch it if the metadata will provide more information to indicate why a file could not be downloaded.

For example, there's no point in going out to Storage on a "507 Insufficient disk space", since the error did not originate from Storage, but rather from Rise Cache itself. Getting the metadata won't indicate a problem.