### PR TITLE
Adding feature for logging usage

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-storage",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "authors": [
     "Rise Vision"
   ],
@@ -20,6 +20,7 @@
   "dependencies": {
     "iron-ajax": "PolymerElements/iron-ajax#^1.0.0",
     "polymer": "Polymer/polymer#^1.0.0",
+    "rise-logger": "https://github.com/Rise-Vision/rise-logger.git#1.0.0",
     "underscore": "~1.8.3"
   },
   "devDependencies": {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -6,6 +6,7 @@
   var colors = require("colors");
   var del = require("del");
   var gulp = require("gulp");
+  var htmlreplace = require("gulp-html-replace");
   var jshint = require("gulp-jshint");
   var runSequence = require("run-sequence");
   var wct = require("web-component-tester").gulp.init(gulp);
@@ -20,6 +21,19 @@
       .pipe(jshint())
       .pipe(jshint.reporter("jshint-stylish"))
       .pipe(jshint.reporter("fail"));
+  });
+
+  gulp.task("version", function() {
+    var pkg = require("./package.json");
+
+    gulp.src("./rise-storage.html")
+      .pipe(htmlreplace({
+        "version": {
+          src: pkg.version,
+          tpl: "<script>var sheetVersion = \"%s\";</script>"
+        }
+      }, {keepBlockTags: true}))
+      .pipe(gulp.dest("./"));
   });
 
   // ***** Primary Tasks ***** //
@@ -40,7 +54,7 @@
     runSequence("test:local", cb);
   });
 
-  gulp.task("build", function (cb) {
+  gulp.task("build", ["version"], function (cb) {
     runSequence("lint", cb);
   });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-storage",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Rise Vision web component for retrieving files from Rise Storage",
   "scripts": {
     "test": "gulp test",
@@ -29,6 +29,7 @@
     "gulp": "~3.8.10",
     "gulp-bower": "~0.0.10",
     "gulp-bump": "~0.2.0",
+    "gulp-html-replace": "~1.6.1",
     "gulp-jshint": "~1.10.0",
     "jshint-stylish": "~1.0.2",
     "run-sequence": "~1.1.0",

--- a/rise-storage.html
+++ b/rise-storage.html
@@ -1,5 +1,6 @@
 <link rel="import" href="../polymer/polymer.html">
 <link rel="import" href="../iron-ajax/iron-ajax.html">
+<link rel="import" href="../rise-logger/rise-logger.html">
 
 <script src="../underscore/underscore.js"></script>
 
@@ -39,6 +40,8 @@ To specify a direction, the `sortDirection` attribute should be used. `sortDirec
 <dom-module id="rise-storage">
   <template>
 
+    <rise-logger id="logger"></rise-logger>
+
     <iron-ajax id="ping"
                url="//localhost:9494"
                handle-as="json"
@@ -73,12 +76,18 @@ To specify a direction, the `sortDirection` attribute should be used. `sortDirec
   </template>
 </dom-module>
 
+<!-- build:version -->
+<script>var sheetVersion = "1.2.0";</script>
+<!-- endbuild -->
+
 <script>
   (function() {
     /* global Polymer, _ */
     /* jshint newcap: false */
 
     "use strict";
+
+    var BQ_TABLE_NAME = "component_storage_events";
 
     Polymer({
       is: "rise-storage",
@@ -143,6 +152,13 @@ To specify a direction, the `sortDirection` attribute should be used. `sortDirec
         refresh: {
           type: Number,
           value: 0
+        },
+        /**
+         * The optional usage type for Rise Vision logging purposes. Options are "standalone" or "widget"
+         */
+        usage: {
+          type: String,
+          value: ""
         },
         /**
          * The environment from which information should be retrieved.
@@ -405,9 +421,23 @@ To specify a direction, the `sortDirection` attribute should be used. `sortDirec
        * Polymer has finished its initialization. This is the entry point.
        */
       ready: function() {
+        var params = {
+          event: "ready"
+        };
+
         this._images = ["image/jpeg", "image/png", "image/bmp", "image/svg+xml", "image/gif", "image/webp"];
         this._videos = ["video/mp4", "video/ogg", "video/webm"];
         this._contentTypes = this.contenttype.split(" ");
+
+        // only include usage_type if it's a valid usage value
+        if (this._isValidUsage(this.usage)) {
+          params.usage_type = this.usage;
+        }
+
+        params.version = sheetVersion;
+
+        // log usage
+        this.$.logger.log(BQ_TABLE_NAME, params);
 
         this.fire("rise-storage-ready");
       },
@@ -420,6 +450,10 @@ To specify a direction, the `sortDirection` attribute should be used. `sortDirec
       },
 
       /***************************************** STORAGE ******************************************/
+
+      _isValidUsage: function(usage) {
+        return usage === "standalone" || usage === "widget";
+      },
 
       _supportsLocalStorage: function() {
         try {

--- a/test/integration/rise-cache.html
+++ b/test/integration/rise-cache.html
@@ -19,13 +19,25 @@
   <script src="../js/rise-storage-subscription-date.js"></script>
 
   <script>
+
+    var folder = document.querySelector("#folder"),
+      cacheFile = document.querySelector("#cache-file"),
+      cacheFileFolder = document.querySelector("#cache-file-folder"),
+      display = "abc123";
+
+    var instances = [folder,cacheFile,cacheFileFolder];
+
+    for (var i = 0; i < instances.length; i += 1) {
+      // mock logger getting display id from Rise Cache
+      sinon.stub(instances[i].$.logger.$.displayId, "generateRequest", function() {
+        instances[i].$.logger._onDisplayIdResponse(null, {response: {displayId: display}});
+      });
+    }
+
     suite("rise-storage", function() {
       var clock,
         server,
         responseHandler,
-        folder = document.querySelector("#folder"),
-        cacheFile = document.querySelector("#cache-file"),
-        cacheFileFolder = document.querySelector("#cache-file-folder"),
         cacheHeader = { "Last-Modified": "Fri, 01 May 2015 15:32:11 GMT", "Location": "//localhost:9494/files/?url=https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fhome.jpg" },
         cacheHeaderFolder = { "Last-Modified": "Fri, 01 May 2015 15:32:11 GMT", "Location": "//localhost:9494/files/?url=https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fimages%252Fhome.jpg" },
         newCacheHeader = { "Last-Modified": "Fri, 24 Apr 2015 15:32:11 GMT", "Location": "//localhost:9494/files?url=https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fhome.jpg" },

--- a/test/integration/rise-storage.html
+++ b/test/integration/rise-storage.html
@@ -22,17 +22,28 @@
   <script src="../js/rise-storage-subscription-date.js"></script>
 
   <script>
-    suite("rise-storage", function() {
 
+    var folder = document.querySelector("#folder"),
+      file = document.querySelector("#file"),
+      fileFolder = document.querySelector("#file-folder"),
+      fileType = document.querySelector("#file-type"),
+      invalidFolder = document.querySelector("#folder-invalid"),
+      contentType = document.querySelector("#content-type"),
+      display = "abc123";
+
+    var instances = [folder,file,fileFolder,fileType,invalidFolder,contentType];
+
+    for (var i = 0; i < instances.length; i += 1) {
+      // mock logger getting display id from Rise Cache
+      sinon.stub(instances[i].$.logger.$.displayId, "generateRequest", function() {
+        instances[i].$.logger._onDisplayIdResponse(null, {response: {displayId: display}});
+      });
+    }
+
+    suite("rise-storage", function() {
       var clock,
         server,
-        responseHandler,
-        folder = document.querySelector("#folder"),
-        file = document.querySelector("#file"),
-        fileFolder = document.querySelector("#file-folder"),
-        fileType = document.querySelector("#file-type"),
-        invalidFolder = document.querySelector("#folder-invalid"),
-        contentType = document.querySelector("#content-type");
+        responseHandler;
 
       // Runs for every test
       setup(function () {

--- a/test/unit/rise-cache.html
+++ b/test/unit/rise-cache.html
@@ -18,13 +18,25 @@
 <script src="../js/rise-storage-data.js"></script>
 
 <script>
+
+  var cacheFolder = document.querySelector("#cache-folder"),
+    cacheFile = document.querySelector("#cache-file"),
+    invalidFolder = document.querySelector("#cache-folder-invalid"),
+    display = "abc123";
+
+  var instances = [cacheFolder, cacheFile, invalidFolder];
+
+  for (var i = 0; i < instances.length; i += 1) {
+    // mock logger getting display id from Rise Cache
+    sinon.stub(instances[i].$.logger.$.displayId, "generateRequest", function() {
+      instances[i].$.logger._onDisplayIdResponse(null, {response: {displayId: display}});
+    });
+  }
+
   suite("rise-storage", function() {
     var responded,
       listener,
       clock,
-      cacheFolder = document.querySelector("#cache-folder"),
-      cacheFile = document.querySelector("#cache-file"),
-      invalidFolder = document.querySelector("#cache-folder-invalid"),
       suffix = "?alt=media";
 
     suiteSetup(function() {

--- a/test/unit/rise-storage-filter.html
+++ b/test/unit/rise-storage-filter.html
@@ -18,12 +18,23 @@
 
   <script src="../js/rise-storage-data.js"></script>
   <script>
+
+    var fileBucket = document.querySelector("#file-bucket"),
+      contentType = document.querySelector("#content-type"),
+      imageFileType = document.querySelector("#image-file-type"),
+      videoFileType = document.querySelector("#video-file-type"),
+      display = "abc123";
+
+    var instances = [fileBucket,contentType,imageFileType,videoFileType];
+
+    for (var i = 0; i < instances.length; i += 1) {
+      // mock logger getting display id from Rise Cache
+      sinon.stub(instances[i].$.logger.$.displayId, "generateRequest", function() {
+        instances[i].$.logger._onDisplayIdResponse(null, {response: {displayId: display}});
+      });
+    }
+
     suite("rise-storage", function() {
-      var
-        fileBucket = document.querySelector("#file-bucket"),
-        contentType = document.querySelector("#content-type"),
-        imageFileType = document.querySelector("#image-file-type"),
-        videoFileType = document.querySelector("#video-file-type");
 
       suite("_filterFiles", function() {
         test("should return true if no fileType or contentType attribute is provided", function() {

--- a/test/unit/rise-storage-sort.html
+++ b/test/unit/rise-storage-sort.html
@@ -15,150 +15,155 @@
 
   <script src="../js/rise-storage-data.js"></script>
   <script>
-    suite("rise-storage", function() {
-      var folder = document.querySelector("#folder");
 
-      suite("_sortFiles", function() {
-        var filesByName =
+    var folder = document.querySelector("#folder"),
+      display = "abc123";
+
+    // mock logger getting display id from Rise Cache
+    sinon.stub(folder.$.logger.$.displayId, "generateRequest", function() {
+      folder.$.logger._onDisplayIdResponse(null, {response: {displayId: display}});
+    });
+
+    suite("_sortFiles", function() {
+      var filesByName =
           [{
             "sortBy": "images/home.jpg",
             "url": "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg"
           },
+            {
+              "sortBy": "images/circle.png",
+              "url": "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png"
+            },
+            {
+              "sortBy": "images/my-image.bmp",
+              "url": "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp"
+            }],
+        filesByDate =
+          [{
+            sortBy: 1423221853313,  // "2015-02-06T11:24:13.313Z"
+            url: "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp"
+          },
+            {
+              sortBy: 1422605949263,  // "2015-01-30T08:19:09.263Z"
+              url: "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg"
+            },
+            {
+              sortBy: 1423071991263,  // "2015-02-04T17:46:31.263Z"
+              url: "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png"
+            }],
+        sortedFiles;
+
+      test("should sort by name in ascending order", function() {
+        folder.sort = "name";
+        folder.sortdirection = "asc";
+        sortedFiles = JSON.stringify(folder._sortFiles(filesByName));
+
+        assert.equal(sortedFiles, JSON.stringify([
           {
-            "sortBy": "images/circle.png",
-            "url": "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png"
+            sortBy: "images/circle.png",
+            url: "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png"
           },
           {
-            "sortBy": "images/my-image.bmp",
-            "url": "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp"
-          }],
-          filesByDate =
-          [{
-              sortBy: 1423221853313,  // "2015-02-06T11:24:13.313Z"
-              url: "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp"
-            },
-            {
-              sortBy: 1422605949263,  // "2015-01-30T08:19:09.263Z"
-              url: "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg"
-            },
-            {
-              sortBy: 1423071991263,  // "2015-02-04T17:46:31.263Z"
-              url: "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png"
-          }],
-          sortedFiles;
+            sortBy: "images/home.jpg",
+            url: "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg"
+          },
+          {
+            sortBy: "images/my-image.bmp",
+            url: "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp"
+          }]
+        ));
+      });
 
-        test("should sort by name in ascending order", function() {
-          folder.sort = "name";
-          folder.sortdirection = "asc";
-          sortedFiles = JSON.stringify(folder._sortFiles(filesByName));
+      test("should sort by name in descending order", function() {
+        folder.sort = "name";
+        folder.sortdirection = "desc";
+        sortedFiles = JSON.stringify(folder._sortFiles(filesByName));
 
-          assert.equal(sortedFiles, JSON.stringify([
-            {
-              sortBy: "images/circle.png",
-              url: "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png"
-            },
-            {
-              sortBy: "images/home.jpg",
-              url: "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg"
-            },
-            {
-              sortBy: "images/my-image.bmp",
-              url: "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp"
-            }]
-          ));
-        });
+        assert.equal(sortedFiles, JSON.stringify([
+          {
+            sortBy: "images/my-image.bmp",
+            url: "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp"
+          },
+          {
+            sortBy: "images/home.jpg",
+            url: "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg"
+          },
+          {
+            sortBy: "images/circle.png",
+            url: "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png"
+          }]
+        ));
+      });
 
-        test("should sort by name in descending order", function() {
-          folder.sort = "name";
-          folder.sortdirection = "desc";
-          sortedFiles = JSON.stringify(folder._sortFiles(filesByName));
+      test("should sort by date in ascending order", function() {
+        folder.sort = "date";
+        folder.sortdirection = "asc";
+        sortedFiles = JSON.stringify(folder._sortFiles(filesByDate));
 
-          assert.equal(sortedFiles, JSON.stringify([
-            {
-              sortBy: "images/my-image.bmp",
-              url: "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp"
-            },
-            {
-              sortBy: "images/home.jpg",
-              url: "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg"
-            },
-            {
-              sortBy: "images/circle.png",
-              url: "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png"
-            }]
-          ));
-        });
+        assert.equal(sortedFiles, JSON.stringify([
+          {
+            sortBy: 1422605949263,  // "2015-01-30T08:19:09.263Z"
+            url: "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg"
+          },
+          {
+            sortBy: 1423071991263,  // "2015-02-04T17:46:31.263Z"
+            url: "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png"
+          },
+          {
+            sortBy: 1423221853313,  // "2015-02-06T11:24:13.313Z"
+            url: "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp"
+          }]
+        ));
+      });
 
-        test("should sort by date in ascending order", function() {
-          folder.sort = "date";
-          folder.sortdirection = "asc";
-          sortedFiles = JSON.stringify(folder._sortFiles(filesByDate));
+      test("should sort by date in descending order", function() {
+        folder.sort = "date";
+        folder.sortdirection = "desc";
+        sortedFiles = JSON.stringify(folder._sortFiles(filesByDate));
 
-          assert.equal(sortedFiles, JSON.stringify([
-            {
-              sortBy: 1422605949263,  // "2015-01-30T08:19:09.263Z"
-              url: "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg"
-            },
-            {
-              sortBy: 1423071991263,  // "2015-02-04T17:46:31.263Z"
-              url: "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png"
-            },
-            {
-              sortBy: 1423221853313,  // "2015-02-06T11:24:13.313Z"
-              url: "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp"
-            }]
-          ));
-        });
+        assert.equal(sortedFiles, JSON.stringify([
+          {
+            sortBy: 1423221853313,  // "2015-02-06T11:24:13.313Z"
+            url: "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp"
+          },
+          {
+            sortBy: 1423071991263,  // "2015-02-04T17:46:31.263Z"
+            url: "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png"
+          },
+          {
+            sortBy: 1422605949263,  // "2015-01-30T08:19:09.263Z"
+            url: "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg"
+          }]
+        ));
+      });
 
-        test("should sort by date in descending order", function() {
-          folder.sort = "date";
-          folder.sortdirection = "desc";
-          sortedFiles = JSON.stringify(folder._sortFiles(filesByDate));
+      test("should sort in random order", function() {
+        folder.sort = "random";
+        sortedFiles = folder._sortFiles(filesByName);
 
-          assert.equal(sortedFiles, JSON.stringify([
-            {
-              sortBy: 1423221853313,  // "2015-02-06T11:24:13.313Z"
-              url: "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp"
-            },
-            {
-              sortBy: 1423071991263,  // "2015-02-04T17:46:31.263Z"
-              url: "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png"
-            },
-            {
-              sortBy: 1422605949263,  // "2015-01-30T08:19:09.263Z"
-              url: "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg"
-            }]
-          ));
-        });
+        // Not possible to predict what order files will be returned in, only that they are returned.
+        assert.equal(sortedFiles.length, 3);
+      });
 
-        test("should sort in random order", function() {
-          folder.sort = "random";
-          sortedFiles = folder._sortFiles(filesByName);
+      test("should sort in ascending order when no sortDirection is provided", function() {
+        folder.sort = "name";
+        folder.sortdirection = null;
+        sortedFiles = JSON.stringify(folder._sortFiles(filesByName));
 
-          // Not possible to predict what order files will be returned in, only that they are returned.
-          assert.equal(sortedFiles.length, 3);
-        });
-
-        test("should sort in ascending order when no sortDirection is provided", function() {
-          folder.sort = "name";
-          folder.sortdirection = null;
-          sortedFiles = JSON.stringify(folder._sortFiles(filesByName));
-
-          assert.equal(sortedFiles, JSON.stringify([
-            {
-              sortBy: "images/circle.png",
-              url: "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png"
-            },
-            {
-              sortBy: "images/home.jpg",
-              url: "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg"
-            },
-            {
-              sortBy: "images/my-image.bmp",
-              url: "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp"
-            }]
-          ));
-        });
+        assert.equal(sortedFiles, JSON.stringify([
+          {
+            sortBy: "images/circle.png",
+            url: "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png"
+          },
+          {
+            sortBy: "images/home.jpg",
+            url: "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg"
+          },
+          {
+            sortBy: "images/my-image.bmp",
+            url: "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp"
+          }]
+        ));
       });
     });
   </script>

--- a/test/unit/rise-storage-subscription.html
+++ b/test/unit/rise-storage-subscription.html
@@ -16,12 +16,24 @@
 
 <script src="../js/rise-storage-data.js"></script>
 <script>
-suite("rise-storage", function() {
-  var responded,
-    listener,
-    fileBucket = document.querySelector("#file-bucket"),
-    fileBucketTest = document.querySelector("#file-bucket-test");
 
+  var fileBucket = document.querySelector("#file-bucket"),
+    fileBucketTest = document.querySelector("#file-bucket-test"),
+    display = "abc123";
+
+  var instances = [fileBucket, fileBucketTest];
+
+  for (var i = 0; i < instances.length; i += 1) {
+    instance = instances[i];
+    // mock logger getting display id from Rise Cache
+    sinon.stub(instances[i].$.logger.$.displayId, "generateRequest", function() {
+      instances[i].$.logger._onDisplayIdResponse(null, {response: {displayId: display}});
+    });
+  }
+
+  suite("rise-storage", function() {
+  var responded,
+    listener;
 
   suiteSetup(function() {
     xhr = sinon.useFakeXMLHttpRequest();
@@ -49,7 +61,7 @@ suite("rise-storage", function() {
       fileBucket._getStorageSubscription();
       assert.equal(fileBucket.$.storageSubscription.url, "https://store-dot-rvaserver2.appspot.com/v1/widget/auth?cid=abc123&pc=b0cba08a4baa0c62b8cdc621b6f6a124f89a03db");
     });
-    
+
     test("should correctly set Test Store request URL", function() {
       fileBucketTest._getStorageSubscription();
       assert.equal(fileBucketTest.$.storageSubscription.url, "https://store-dot-rvacore-test.appspot.com/v1/widget/auth?cid=abc123&pc=b0cba08a4baa0c62b8cdc621b6f6a124f89a03db");

--- a/test/unit/rise-storage.html
+++ b/test/unit/rise-storage.html
@@ -22,18 +22,30 @@
 
   <script src="../js/rise-storage-data.js"></script>
   <script>
+
+    var noCompany = document.querySelector("#noCompany"),
+      bucket = document.querySelector("#bucket"),
+      folder = document.querySelector("#folder"),
+      invalidFolder = document.querySelector("#invalid-folder"),
+      folderTesting = document.querySelector("#folder-testing"),
+      fileFolder = document.querySelector("#file-folder"),
+      fileBucket = document.querySelector("#file-bucket"),
+      contentType = document.querySelector("#content-type"),
+      display = "abc123";
+
+    var instances = [noCompany,bucket,folder,invalidFolder,folderTesting,fileFolder,fileBucket,contentType];
+
+    for (var i = 0; i < instances.length; i += 1) {
+      // mock logger getting display id from Rise Cache
+      sinon.stub(instances[i].$.logger.$.displayId, "generateRequest", function() {
+        instances[i].$.logger._onDisplayIdResponse(null, {response: {displayId: display}});
+      });
+    }
+
     suite("rise-storage", function() {
       var responded,
         listener,
         clock,
-        noCompany = document.querySelector("#noCompany"),
-        bucket = document.querySelector("#bucket"),
-        folder = document.querySelector("#folder"),
-        invalidFolder = document.querySelector("#invalid-folder"),
-        folderTesting = document.querySelector("#folder-testing"),
-        fileFolder = document.querySelector("#file-folder"),
-        fileBucket = document.querySelector("#file-bucket"),
-        contentType = document.querySelector("#content-type"),
         suffix = "?alt=media";
 
       suiteSetup(function() {
@@ -57,6 +69,17 @@
       });
 
       suite("ready", function() {
+        var logStub;
+
+        setup(function() {
+          logStub = sinon.stub(bucket.$.logger, "log");
+        });
+
+        teardown(function() {
+          logStub.restore();
+          bucket.usage = "";
+        });
+
         test("should set the number of supported image types", function() {
           bucket.ready();
           assert.equal(bucket._images.length, 6);
@@ -72,6 +95,19 @@
           assert.equal(contentType._contentTypes.length, 2);
         });
 
+        test("should log usage", function () {
+          bucket.ready();
+          assert.equal(logStub.args[0][0],"component_storage_events");
+          assert.include(JSON.stringify(logStub.args[0][1]),"{\"event\":\"ready\",\"version\":");
+        });
+
+        test("should log usage and include 'usage_type'", function() {
+          bucket.usage = "widget";
+          bucket.ready();
+          assert.equal(logStub.args[0][0],"component_storage_events");
+          assert.include(JSON.stringify(logStub.args[0][1]),"{\"event\":\"ready\",\"usage_type\":\"widget\",\"version\":");
+        });
+
         test("should fire rise-storage-ready", function (done) {
           listener = function() {
             responded = true;
@@ -83,6 +119,19 @@
           assert.isTrue(responded);
           done();
         });
+      });
+
+      suite("_isValidUsage", function () {
+
+        test("should return true when 'standalone' or 'widget'", function () {
+          assert.isTrue(fileFolder._isValidUsage("widget"));
+          assert.isTrue(fileFolder._isValidUsage("standalone"));
+        });
+
+        test("should return false when invalid", function () {
+          assert.isFalse(fileFolder._isValidUsage("test"));
+        });
+
       });
 
       suite("_computeStorageUrl", function() {


### PR DESCRIPTION
- Using `rise-logger` and logging usage from `ready()` lifecycle.
- Adding `usage` property to allow for a Widget to set a value of "widget"
- Added gulp task "version" when building which injects source for referencing component version (via block tags)
- Logging version
- Revised and added unit tests