### PR TITLE
Appending `mode` param to file urls when RC not running

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-storage",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "authors": [
     "Rise Vision"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-storage",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Rise Vision web component for retrieving files from Rise Storage",
   "scripts": {
     "test": "gulp test",

--- a/rise-storage.html
+++ b/rise-storage.html
@@ -743,6 +743,7 @@ To specify a direction, the `sortDirection` attribute should be used. `sortDirec
           file = {},
           previousItem = null,
           suffix = "?alt=media",
+          modeSuffix = "&mode=preview",
           filesFiltered = 0,
           totalFiles = 0;
 
@@ -787,7 +788,7 @@ To specify a direction, the `sortDirection` attribute should be used. `sortDirec
                     file.url = self._baseCacheUrl + "/files/?url=" + encodeURIComponent(item.selfLink + suffix);
                   }
                   else {
-                    file.url = item.selfLink + suffix;
+                    file.url = item.selfLink + suffix + modeSuffix;
                   }
 
                   self._files.push({
@@ -805,7 +806,7 @@ To specify a direction, the `sortDirection` attribute should be used. `sortDirec
                       encodeURIComponent(item.selfLink + suffix);
                   }
                   else {
-                    file.url = item.selfLink + suffix;
+                    file.url = item.selfLink + suffix + modeSuffix;
                   }
 
                   previousItem = _.find(self._files, function(obj) {
@@ -1289,7 +1290,7 @@ To specify a direction, the `sortDirection` attribute should be used. `sortDirec
       },
 
       _getSingleFileURL: function() {
-        return "https://storage.googleapis.com/" + encodeURIComponent(this._getStoragePath());
+        return "https://storage.googleapis.com/" + encodeURIComponent(this._getStoragePath()) + ((!this._isCacheRunning) ? "?mode=preview" : "");
       },
 
       /**
@@ -1379,7 +1380,8 @@ To specify a direction, the `sortDirection` attribute should be used. `sortDirec
           filePath = "",
           startIndex = -1,
           endIndex = -1,
-          suffix = "?alt=media";
+          suffix = "?alt=media",
+          modeSuffix = "&mode=preview";
 
         // File in the root of the bucket.
         if (response.selfLink) {
@@ -1400,7 +1402,7 @@ To specify a direction, the `sortDirection` attribute should be used. `sortDirec
           this._fileUrl = encodeURIComponent("https://storage.googleapis.com/" + bucket + "/" + filePath);
         }
         else {
-          this._fileUrl = url + suffix;
+          this._fileUrl = url + suffix + modeSuffix;
         }
       },
 

--- a/test/integration/rise-storage.html
+++ b/test/integration/rise-storage.html
@@ -84,7 +84,7 @@
         test("should return the correct URL for a specific file in a bucket after 24 hours has passed since last check of the subscription status", function(done) {
           responseHandler = function(response) {
             assert.equal(response.detail.name, "home.jpg");
-            assert.equal(response.detail.url, "https://storage.googleapis.com/risemedialibrary-abc123%2Fhome.jpg");
+            assert.equal(response.detail.url, "https://storage.googleapis.com/risemedialibrary-abc123%2Fhome.jpg?mode=preview");
             done();
           };
 
@@ -98,7 +98,7 @@
         test("should return the correct URL for a specific file in a bucket", function(done) {
           responseHandler = function(response) {
             assert.equal(response.detail.name, "home.jpg");
-            assert.equal(response.detail.url, "https://storage.googleapis.com/risemedialibrary-abc123%2Fhome.jpg");
+            assert.equal(response.detail.url, "https://storage.googleapis.com/risemedialibrary-abc123%2Fhome.jpg?mode=preview");
             done();
           };
 
@@ -149,7 +149,7 @@
         test("should return the correct URL for a specific file in a folder", function(done) {
           responseHandler = function(response) {
             assert.equal(response.detail.name, "images/home.jpg");
-            assert.equal(response.detail.url, "https://storage.googleapis.com/risemedialibrary-abc123%2Fimages%2Fhome.jpg");
+            assert.equal(response.detail.url, "https://storage.googleapis.com/risemedialibrary-abc123%2Fimages%2Fhome.jpg?mode=preview");
             done();
           };
 
@@ -210,9 +210,9 @@
               assert.equal(files[0].name, "images/home.jpg");
               assert.equal(files[1].name, "images/circle.png");
               assert.equal(files[2].name, "images/my-image.bmp");
-              assert.equal(files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media");
-              assert.equal(files[1].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media");
-              assert.equal(files[2].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp?alt=media");
+              assert.equal(files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media&mode=preview");
+              assert.equal(files[1].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media&mode=preview");
+              assert.equal(files[2].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp?alt=media&mode=preview");
               done();
             }
           };
@@ -243,7 +243,7 @@
           responseHandler = function(response) {
             if (response.detail.changed) {
               assert.equal(response.detail.name, "images/circle.png");
-              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media");
+              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media&mode=preview");
               done();
             }
           };
@@ -263,7 +263,7 @@
 
             if (response.detail.added && count > 3) {
               assert.equal(response.detail.name, "images/golf.svg");
-              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fgolf.svg?alt=media");
+              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fgolf.svg?alt=media&mode=preview");
               done();
             }
           };
@@ -285,7 +285,7 @@
           responseHandler = function(response) {
             if (response.detail.deleted) {
               assert.equal(response.detail.name, "images/golf.svg");
-              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fgolf.svg?alt=media");
+              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fgolf.svg?alt=media&mode=preview");
               done();
             }
           };
@@ -612,7 +612,7 @@
         test("should fire rise-storage-file-throttled if bucket file is throttled", function(done) {
           responseHandler = function(response) {
             assert.isString(response.detail, "response.detail is a string");
-            assert.equal(response.detail, bucketImage.files[0].selfLink + "?alt=media");
+            assert.equal(response.detail, bucketImage.files[0].selfLink + "?alt=media&mode=preview");
 
             file.removeEventListener("rise-storage-file-throttled", responseHandler);
 
@@ -629,7 +629,7 @@
         test("should fire rise-storage-file-throttled if folder file is throttled", function(done) {
           responseHandler = function(response) {
             assert.isString(response.detail, "response.detail is a string");
-            assert.equal(response.detail, folderImage.files[0].selfLink + "?alt=media");
+            assert.equal(response.detail, folderImage.files[0].selfLink + "?alt=media&mode=preview");
 
             fileFolder.removeEventListener("rise-storage-file-throttled", responseHandler);
 
@@ -732,8 +732,8 @@
             if(files.length === 2) {
               assert.equal(files[0].name, "images/home.jpg");
               assert.equal(files[1].name, "images/my-image.bmp");
-              assert.equal(files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media");
-              assert.equal(files[1].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp?alt=media");
+              assert.equal(files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media&mode=preview");
+              assert.equal(files[1].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp?alt=media&mode=preview");
               done();
             }
           };

--- a/test/unit/rise-cache.html
+++ b/test/unit/rise-cache.html
@@ -37,7 +37,8 @@
     var responded,
       listener,
       clock,
-      suffix = "?alt=media";
+      suffix = "?alt=media",
+      modeSuffix = "&mode=preview";
 
     suiteSetup(function() {
       xhr = sinon.useFakeXMLHttpRequest();
@@ -590,13 +591,13 @@
       test("should correctly set fileUrl for a file in the root of the bucket when Rise Cache is not running", function() {
         cacheFile._isCacheRunning = false;
         cacheFile._setFileUrl(bucketImage);
-        assert.equal(cacheFile._fileUrl, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg" + suffix);
+        assert.equal(cacheFile._fileUrl, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg" + suffix + modeSuffix);
       });
 
       test("should correctly set fileUrl for a file in a folder when Rise Cache is not running", function() {
         cacheFolder._isCacheRunning = false;
         cacheFolder._setFileUrl(folderImage);
-        assert.equal(cacheFolder._fileUrl, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg" + suffix);
+        assert.equal(cacheFolder._fileUrl, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg" + suffix + modeSuffix);
       });
     });
 

--- a/test/unit/rise-storage.html
+++ b/test/unit/rise-storage.html
@@ -46,7 +46,8 @@
       var responded,
         listener,
         clock,
-        suffix = "?alt=media";
+        suffix = "?alt=media",
+        modeSuffix = "&mode=preview";
 
       suiteSetup(function() {
         xhr = sinon.useFakeXMLHttpRequest();
@@ -274,11 +275,11 @@
             listener = function(response) {
               responded = true;
               assert.equal(response.detail.name, "home.jpg");
-              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg?alt=media");
+              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg?alt=media&mode=preview");
             };
 
             fileBucket.addEventListener("rise-storage-response", listener);
-            fileBucket._fileUrl = url + suffix;
+            fileBucket._fileUrl = url + suffix + modeSuffix;
             fileBucket._handleStorageFile(bucketImage);
 
             assert.isTrue(responded);
@@ -304,7 +305,7 @@
               responded = true;
               assert.isTrue(response.detail.changed);
               assert.equal(response.detail.name, "home.jpg");
-              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg?alt=media");
+              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg?alt=media&mode=preview");
               fileBucket.removeEventListener("rise-storage-response", listener);
               fileBucket._isLoading = true;
             };
@@ -335,11 +336,11 @@
             listener = function(response) {
               responded = true;
               assert.equal(response.detail.name, "images/home.jpg");
-              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media");
+              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media&mode=preview");
             };
 
             fileFolder.addEventListener("rise-storage-response", listener);
-            fileFolder._fileUrl = url + suffix;
+            fileFolder._fileUrl = url + suffix + modeSuffix;
             fileFolder._handleStorageFile(folderImage);
 
             assert.isTrue(responded);
@@ -364,7 +365,7 @@
               responded = true;
               assert.isTrue(response.detail.changed);
               assert.equal(response.detail.name, "images/home.jpg");
-              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media");
+              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media&mode=preview");
               fileFolder._isLoading = true;
             };
 
@@ -404,9 +405,9 @@
               assert.equal(files[0].name, "images/home.jpg");
               assert.equal(files[1].name, "images/circle.png");
               assert.equal(files[2].name, "images/my-image.bmp");
-              assert.equal(files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media");
-              assert.equal(files[1].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media");
-              assert.equal(files[2].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp?alt=media");
+              assert.equal(files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media&mode=preview");
+              assert.equal(files[1].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media&mode=preview");
+              assert.equal(files[2].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp?alt=media&mode=preview");
             }
           };
 
@@ -428,9 +429,9 @@
               assert.equal(files[0].name, "images/home.jpg");
               assert.equal(files[1].name, "images/circle.png");
               assert.equal(files[2].name, "images/my-image.bmp");
-              assert.equal(files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media");
-              assert.equal(files[1].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media");
-              assert.equal(files[2].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp?alt=media");
+              assert.equal(files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media&mode=preview");
+              assert.equal(files[1].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media&mode=preview");
+              assert.equal(files[2].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp?alt=media&mode=preview");
             }
           };
 
@@ -446,7 +447,7 @@
             if (response.detail.changed) {
               responded = true;
               assert.equal(response.detail.name, "images/circle.png");
-              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media");
+              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media&mode=preview");
             }
           };
 
@@ -463,7 +464,7 @@
             if (response.detail.added) {
               responded = true;
               assert.equal(response.detail.name, "images/golf.svg");
-              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fgolf.svg?alt=media");
+              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fgolf.svg?alt=media&mode=preview");
             }
           };
 
@@ -487,7 +488,7 @@
             if (response.detail.deleted) {
               responded = true;
               assert.equal(response.detail.name, "images/golf.svg");
-              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fgolf.svg?alt=media");
+              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fgolf.svg?alt=media&mode=preview");
             }
           };
 
@@ -640,11 +641,11 @@
       suite("_getSingleFileURL", function() {
 
         test("should return the storage url of the file in a bucket", function() {
-          assert.equal(fileBucket._getSingleFileURL(), "https://storage.googleapis.com/risemedialibrary-abc123%2Fhome.jpg");
+          assert.equal(fileBucket._getSingleFileURL(), "https://storage.googleapis.com/risemedialibrary-abc123%2Fhome.jpg?mode=preview");
         });
 
         test("should return the storage url of the file in a folder", function() {
-          assert.equal(fileFolder._getSingleFileURL(), "https://storage.googleapis.com/risemedialibrary-abc123%2Fimages%2Fhome.jpg");
+          assert.equal(fileFolder._getSingleFileURL(), "https://storage.googleapis.com/risemedialibrary-abc123%2Fimages%2Fhome.jpg?mode=preview");
         });
 
       });


### PR DESCRIPTION
- Including `mode=preview` to all file url configurations (file and folder files) when RC is  not running
- Unit and integration tests revised
- Feature version bump