### PR TITLE
Fix refresh not working for staggered downloads

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-storage",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "authors": [
     "Rise Vision"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-storage",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Rise Vision web component for retrieving files from Rise Storage",
   "scripts": {
     "test": "gulp test",

--- a/rise-storage.html
+++ b/rise-storage.html
@@ -77,7 +77,7 @@ To specify a direction, the `sortDirection` attribute should be used. `sortDirec
 </dom-module>
 
 <!-- build:version -->
-<script>var sheetVersion = "1.3.0";</script>
+<script>var sheetVersion = "1.3.1";</script>
 <!-- endbuild -->
 
 <script>

--- a/rise-storage.html
+++ b/rise-storage.html
@@ -77,7 +77,7 @@ To specify a direction, the `sortDirection` attribute should be used. `sortDirec
 </dom-module>
 
 <!-- build:version -->
-<script>var sheetVersion = "1.2.0";</script>
+<script>var sheetVersion = "1.3.0";</script>
 <!-- endbuild -->
 
 <script>
@@ -344,6 +344,15 @@ To specify a direction, the `sortDirection` attribute should be used. `sortDirec
        * @default false
        */
       _pingReceived: false,
+
+      /**
+       * The number of files in a folder that have already been downloaded.
+       *
+       * @property _downloadedFiles
+       * @type number
+       * @default 0
+       */
+      _downloadedFiles: 0,
 
       /**
        * The number of files in a folder that have already been processed.
@@ -896,6 +905,7 @@ To specify a direction, the `sortDirection` attribute should be used. `sortDirec
 
         if (resp.files) {
           this._numFiles = 0;
+          this._downloadedFiles = 0;
 
           // Only count actual files (ignore folders)
           this._totalFiles = resp.files.filter(function(item) {
@@ -1110,26 +1120,27 @@ To specify a direction, the `sortDirection` attribute should be used. `sortDirec
 
             file.name = this._getFileNameFromUrl(file.url);
 
+            this._downloadedFiles++;
             this.fire("rise-storage-response", file);
-
             this._removeHandledFile(file.name);
           }
         }
 
         this._numFiles++;
 
-        if (this._numFiles === this._totalFiles) {
+        if (this._downloadedFiles === this._totalFiles) {
+          this._startTimer();
+          this._isLoading = false;
+        } else if (this._numFiles === this._totalFiles) {
           if (this._isFolderFileDownloadingByCache) {
             this._totalCacheRequests++;
+
             // Retry cache request a maximum of 3 times.
             if (this._totalCacheRequests < 3) {
               this._retryCacheRequest(this._retryCacheRequestForFolder);
             } else {
               this.fire("rise-cache-folder-unavailable", this._folderFilesToRequest);
             }
-          } else {
-            this._startTimer();
-            this._isLoading = false;
           }
         }
       },
@@ -1548,6 +1559,7 @@ To specify a direction, the `sortDirection` attribute should be used. `sortDirec
         this._files = [];
         this._isCacheRunning = false;
         this._pingReceived = false;
+        this._downloadedFiles = 0;
         this._numFiles = 0;
         this._totalFiles = 0;
         this._cacheRequestMethod = "HEAD";


### PR DESCRIPTION
If files in a folder returned a 202 and needed to be retried, it was possible for `_startTimer` to never be called in `_handleCacheFolder` because `this._numFiles` would get reset to 0 and would never equal `this._totalFiles` - https://github.com/Rise-Vision/rise-storage/blob/master/rise-storage.html#L1121.

Instead, introduce a separate `this._downloadedFiles` counter that is only reset after a refresh.