### PR TITLE
Start refresh timer after firing empty folder event

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-storage",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "authors": [
     "Rise Vision"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-storage",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "description": "Rise Vision web component for retrieving files from Rise Storage",
   "scripts": {
     "test": "gulp test",

--- a/rise-storage.html
+++ b/rise-storage.html
@@ -77,7 +77,7 @@ To specify a direction, the `sortDirection` attribute should be used. `sortDirec
 </dom-module>
 
 <!-- build:version -->
-<script>var sheetVersion = "1.3.1";</script>
+<script>var sheetVersion = "1.3.2";</script>
 <!-- endbuild -->
 
 <script>
@@ -618,6 +618,7 @@ To specify a direction, the `sortDirection` attribute should be used. `sortDirec
             }
           }
           else if (this._isEmptyFolder(resp.response)) {
+            this._startTimer();
             this.fire("rise-storage-empty-folder");
           }
           else if (this._noFolderExists(resp.response)) {

--- a/test/integration/rise-storage.html
+++ b/test/integration/rise-storage.html
@@ -386,13 +386,19 @@
         });
 
         test("should fire rise-storage-empty-folder if a folder is empty", function(done) {
+          var startTimerSpy = sinon.spy( folder, "_startTimer" );
+
           responseHandler = function(response) {
             assert.isObject(response.detail, "response.detail is an object");
             assert.deepEqual(response.detail, {}, "response.detail is an empty object");
+            assert.isTrue(startTimerSpy.calledOnce);
+
+            startTimerSpy.restore();
 
             done();
           };
 
+          folder.refresh = 5;
           folder.addEventListener("rise-storage-empty-folder", responseHandler);
           server.respondWith([200, header, JSON.stringify(emptyFolder)]);
           folder.go();


### PR DESCRIPTION
- Ensures a refresh timer will start when scenario of empty folder occurs
- Unit test revised
- Minor patch version bump