### PR TITLE
Applying mode param value "no-rc" when RC down and running in player

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-storage",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "authors": [
     "Rise Vision"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-storage",
-  "version": "1.3.2",
+  "version": "1.4.0",
   "description": "Rise Vision web component for retrieving files from Rise Storage",
   "scripts": {
     "test": "gulp test",

--- a/rise-storage.html
+++ b/rise-storage.html
@@ -77,7 +77,7 @@ To specify a direction, the `sortDirection` attribute should be used. `sortDirec
 </dom-module>
 
 <!-- build:version -->
-<script>var sheetVersion = "1.3.2";</script>
+<script>var sheetVersion = "1.4.0";</script>
 <!-- endbuild -->
 
 <script>
@@ -89,6 +89,9 @@ To specify a direction, the `sortDirection` attribute should be used. `sortDirec
 
     var BQ_TABLE_NAME = "component_storage_events";
 
+    var MODE_PREVIEW = "preview",
+      MODE_PLAYER = "no-rc";
+
     Polymer({
       is: "rise-storage",
 
@@ -97,6 +100,13 @@ To specify a direction, the `sortDirection` attribute should be used. `sortDirec
          * The ID of the Company.
          */
         companyid: {
+          type: String,
+          value: ""
+        },
+        /**
+         * The ID of the Display.
+         */
+        displayid: {
           type: String,
           value: ""
         },
@@ -423,7 +433,6 @@ To specify a direction, the `sortDirection` attribute should be used. `sortDirec
        */
       _isSubscribed: false,
 
-
       /************************************** INITIALIZATION **************************************/
 
       /**
@@ -462,6 +471,13 @@ To specify a direction, the `sortDirection` attribute should be used. `sortDirec
 
       _isValidUsage: function(usage) {
         return usage === "standalone" || usage === "widget";
+      },
+
+      _isPlayerRunning: function() {
+        return this.displayid !== "" &&
+          this.displayid !== "preview" &&
+          this.displayid !== "display_id" &&
+          this.displayid !== "displayId";
       },
 
       _supportsLocalStorage: function() {
@@ -753,7 +769,7 @@ To specify a direction, the `sortDirection` attribute should be used. `sortDirec
           file = {},
           previousItem = null,
           suffix = "?alt=media",
-          modeSuffix = "&mode=preview",
+          modeSuffix = "&mode=",
           filesFiltered = 0,
           totalFiles = 0;
 
@@ -798,7 +814,7 @@ To specify a direction, the `sortDirection` attribute should be used. `sortDirec
                     file.url = self._baseCacheUrl + "/files/?url=" + encodeURIComponent(item.selfLink + suffix);
                   }
                   else {
-                    file.url = item.selfLink + suffix + modeSuffix;
+                    file.url = item.selfLink + suffix + modeSuffix + ((self._isPlayerRunning()) ? MODE_PLAYER : MODE_PREVIEW);
                   }
 
                   self._files.push({
@@ -816,7 +832,7 @@ To specify a direction, the `sortDirection` attribute should be used. `sortDirec
                       encodeURIComponent(item.selfLink + suffix);
                   }
                   else {
-                    file.url = item.selfLink + suffix + modeSuffix;
+                    file.url = item.selfLink + suffix + modeSuffix + ((self._isPlayerRunning()) ? MODE_PLAYER : MODE_PREVIEW);
                   }
 
                   previousItem = _.find(self._files, function(obj) {
@@ -1302,7 +1318,9 @@ To specify a direction, the `sortDirection` attribute should be used. `sortDirec
       },
 
       _getSingleFileURL: function() {
-        return "https://storage.googleapis.com/" + encodeURIComponent(this._getStoragePath()) + ((!this._isCacheRunning) ? "?mode=preview" : "");
+        var suffix = (!this._isCacheRunning) ? "?mode=" + ((this._isPlayerRunning()) ? MODE_PLAYER : MODE_PREVIEW) : "";
+
+        return "https://storage.googleapis.com/" + encodeURIComponent(this._getStoragePath()) + suffix;
       },
 
       /**
@@ -1393,7 +1411,7 @@ To specify a direction, the `sortDirection` attribute should be used. `sortDirec
           startIndex = -1,
           endIndex = -1,
           suffix = "?alt=media",
-          modeSuffix = "&mode=preview";
+          modeSuffix = "&mode=";
 
         // File in the root of the bucket.
         if (response.selfLink) {
@@ -1414,7 +1432,7 @@ To specify a direction, the `sortDirection` attribute should be used. `sortDirec
           this._fileUrl = encodeURIComponent("https://storage.googleapis.com/" + bucket + "/" + filePath);
         }
         else {
-          this._fileUrl = url + suffix + modeSuffix;
+          this._fileUrl = url + suffix + modeSuffix + ((this._isPlayerRunning()) ? MODE_PLAYER : MODE_PREVIEW);
         }
       },
 

--- a/test/integration/rise-storage.html
+++ b/test/integration/rise-storage.html
@@ -95,13 +95,26 @@
           file.go();
         });
 
-        test("should return the correct URL for a specific file in a bucket", function(done) {
+        test("should return the correct URL for a specific file in a bucket when running in player", function(done) {
+          responseHandler = function(response) {
+            assert.equal(response.detail.name, "home.jpg");
+            assert.equal(response.detail.url, "https://storage.googleapis.com/risemedialibrary-abc123%2Fhome.jpg?mode=no-rc");
+            done();
+          };
+
+          file.displayid = "def456";
+          file.addEventListener("rise-storage-response", responseHandler);
+          file.go();
+        });
+
+        test("should return the correct URL for a specific file in a bucket when running in preview", function(done) {
           responseHandler = function(response) {
             assert.equal(response.detail.name, "home.jpg");
             assert.equal(response.detail.url, "https://storage.googleapis.com/risemedialibrary-abc123%2Fhome.jpg?mode=preview");
             done();
           };
 
+          file.displayid = "preview";
           file.addEventListener("rise-storage-response", responseHandler);
           file.go();
         });
@@ -146,13 +159,26 @@
           fileFolder.removeEventListener("rise-storage-response", responseHandler);
         });
 
-        test("should return the correct URL for a specific file in a folder", function(done) {
+        test("should return the correct URL for a specific file in a folder when running in player", function(done) {
+          responseHandler = function(response) {
+            assert.equal(response.detail.name, "images/home.jpg");
+            assert.equal(response.detail.url, "https://storage.googleapis.com/risemedialibrary-abc123%2Fimages%2Fhome.jpg?mode=no-rc");
+            done();
+          };
+
+          fileFolder.displayid = "def456";
+          fileFolder.addEventListener("rise-storage-response", responseHandler);
+          fileFolder.go();
+        });
+
+        test("should return the correct URL for a specific file in a folder when running in preview", function(done) {
           responseHandler = function(response) {
             assert.equal(response.detail.name, "images/home.jpg");
             assert.equal(response.detail.url, "https://storage.googleapis.com/risemedialibrary-abc123%2Fimages%2Fhome.jpg?mode=preview");
             done();
           };
 
+          fileFolder.displayid = "preview";
           fileFolder.addEventListener("rise-storage-response", responseHandler);
           fileFolder.go();
         });
@@ -200,7 +226,31 @@
           folder.removeEventListener("rise-storage-response", responseHandler);
         });
 
-        test("should return the correct URLs for files in a folder", function(done) {
+        test("should return the correct URLs for files in a folder when running in player", function(done) {
+          var files = [];
+
+          responseHandler = function(response) {
+            files.push(response.detail);
+
+            if(files.length === 3) {
+              assert.equal(files[0].name, "images/home.jpg");
+              assert.equal(files[1].name, "images/circle.png");
+              assert.equal(files[2].name, "images/my-image.bmp");
+              assert.equal(files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media&mode=no-rc");
+              assert.equal(files[1].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media&mode=no-rc");
+              assert.equal(files[2].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp?alt=media&mode=no-rc");
+              done();
+            }
+          };
+
+
+          folder.displayid = "def456";
+          folder.addEventListener("rise-storage-response", responseHandler);
+          server.respondWith([200, header, JSON.stringify(images)]);
+          folder.go();
+        });
+
+        test("should return the correct URLs for files in a folder when running in preview", function(done) {
           var files = [];
 
           responseHandler = function(response) {
@@ -217,7 +267,10 @@
             }
           };
 
-
+          folder._reset();
+          folder._isCacheRunning = false;
+          folder._pingReceived = true;
+          folder.displayid = "preview";
           folder.addEventListener("rise-storage-response", responseHandler);
           server.respondWith([200, header, JSON.stringify(images)]);
           folder.go();

--- a/test/unit/rise-cache.html
+++ b/test/unit/rise-cache.html
@@ -38,7 +38,7 @@
       listener,
       clock,
       suffix = "?alt=media",
-      modeSuffix = "&mode=preview";
+      modeSuffix = "&mode=";
 
     suiteSetup(function() {
       xhr = sinon.useFakeXMLHttpRequest();
@@ -576,6 +576,12 @@
     });
 
     suite("_setFileUrl", function() {
+
+      suiteTeardown(function() {
+        cacheFile.displayid = "";
+        cacheFolder.displayid = "";
+      });
+
       test("should correctly set fileUrl for a file in the root of the bucket when Rise Cache is running", function() {
         cacheFile._isCacheRunning = true;
         cacheFile._setFileUrl(bucketImage);
@@ -588,16 +594,32 @@
         assert.equal(cacheFolder._fileUrl, "https%3A%2F%2Fstorage.googleapis.com%2Frisemedialibrary-abc123%2Fimages%252Fhome.jpg");
       });
 
-      test("should correctly set fileUrl for a file in the root of the bucket when Rise Cache is not running", function() {
+      test("should correctly set fileUrl for a file in the root of the bucket when Rise Cache is not running and in player", function() {
         cacheFile._isCacheRunning = false;
+        cacheFile.displayid = "def456";
         cacheFile._setFileUrl(bucketImage);
-        assert.equal(cacheFile._fileUrl, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg" + suffix + modeSuffix);
+        assert.equal(cacheFile._fileUrl, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg" + suffix + modeSuffix + "no-rc");
       });
 
-      test("should correctly set fileUrl for a file in a folder when Rise Cache is not running", function() {
+      test("should correctly set fileUrl for a file in the root of the bucket when Rise Cache is not running and in preview", function() {
+        cacheFile._isCacheRunning = false;
+        cacheFile.displayid = "preview";
+        cacheFile._setFileUrl(bucketImage);
+        assert.equal(cacheFile._fileUrl, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg" + suffix + modeSuffix + "preview");
+      });
+
+      test("should correctly set fileUrl for a file in a folder when Rise Cache is not running and in player", function() {
         cacheFolder._isCacheRunning = false;
+        cacheFolder.displayid = "def456";
         cacheFolder._setFileUrl(folderImage);
-        assert.equal(cacheFolder._fileUrl, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg" + suffix + modeSuffix);
+        assert.equal(cacheFolder._fileUrl, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg" + suffix + modeSuffix + "no-rc");
+      });
+
+      test("should correctly set fileUrl for a file in a folder when Rise Cache is not running and in preview", function() {
+        cacheFolder._isCacheRunning = false;
+        cacheFolder.displayid = "preview";
+        cacheFolder._setFileUrl(folderImage);
+        assert.equal(cacheFolder._fileUrl, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg" + suffix + modeSuffix + "preview");
       });
     });
 

--- a/test/unit/rise-storage.html
+++ b/test/unit/rise-storage.html
@@ -47,7 +47,7 @@
         listener,
         clock,
         suffix = "?alt=media",
-        modeSuffix = "&mode=preview";
+        modeSuffix = "&mode=";
 
       suiteSetup(function() {
         xhr = sinon.useFakeXMLHttpRequest();
@@ -269,17 +269,35 @@
 
           teardown(function () {
             fileBucket.removeEventListener("rise-storage-response", listener);
+            fileBucket.displayid = "";
           });
 
-          test("should return the correct URL for a specific file in a bucket", function(done) {
+          test("should return the correct URL for a specific file in a bucket running in player", function(done) {
+            listener = function(response) {
+              responded = true;
+              assert.equal(response.detail.name, "home.jpg");
+              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg?alt=media&mode=no-rc");
+            };
+
+            fileBucket.displayid = "def456";
+            fileBucket.addEventListener("rise-storage-response", listener);
+            fileBucket._fileUrl = url + suffix + modeSuffix + "no-rc";
+            fileBucket._handleStorageFile(bucketImage);
+
+            assert.isTrue(responded);
+            done();
+          });
+
+          test("should return the correct URL for a specific file in a bucket running in preview", function(done) {
             listener = function(response) {
               responded = true;
               assert.equal(response.detail.name, "home.jpg");
               assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/home.jpg?alt=media&mode=preview");
             };
 
+            fileBucket.displayid = "preview";
             fileBucket.addEventListener("rise-storage-response", listener);
-            fileBucket._fileUrl = url + suffix + modeSuffix;
+            fileBucket._fileUrl = url + suffix + modeSuffix + "preview";
             fileBucket._handleStorageFile(bucketImage);
 
             assert.isTrue(responded);
@@ -330,17 +348,35 @@
 
           teardown(function() {
             fileFolder.removeEventListener("rise-storage-response", listener);
+            fileFolder.displayid = "";
           });
 
-          test("should return the correct URL for a specific file in a bucket", function(done) {
+          test("should return the correct URL for a specific file in a bucket running in player", function(done) {
+            listener = function(response) {
+              responded = true;
+              assert.equal(response.detail.name, "images/home.jpg");
+              assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media&mode=no-rc");
+            };
+
+            fileFolder.displayid = "def456";
+            fileFolder.addEventListener("rise-storage-response", listener);
+            fileFolder._fileUrl = url + suffix + modeSuffix + "no-rc";
+            fileFolder._handleStorageFile(folderImage);
+
+            assert.isTrue(responded);
+            done();
+          });
+
+          test("should return the correct URL for a specific file in a bucket running in preview", function(done) {
             listener = function(response) {
               responded = true;
               assert.equal(response.detail.name, "images/home.jpg");
               assert.equal(response.detail.url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media&mode=preview");
             };
 
+            fileFolder.displayid = "preview";
             fileFolder.addEventListener("rise-storage-response", listener);
-            fileFolder._fileUrl = url + suffix + modeSuffix;
+            fileFolder._fileUrl = url + suffix + modeSuffix + "preview";
             fileFolder._handleStorageFile(folderImage);
 
             assert.isTrue(responded);
@@ -392,9 +428,36 @@
 
         teardown(function() {
           images = localImages;
+          folder.removeEventListener("rise-storage-response", listener);
+          folder.displayid = "";
         });
 
-        test("should return the correct URLs for files in a folder", function(done) {
+        test("should return the correct URLs for files in a folder running in player", function(done) {
+          var files = [];
+
+          listener = function(response) {
+            files.push(response.detail);
+
+            if(files.length === 3) {
+              responded = true;
+              assert.equal(files[0].name, "images/home.jpg");
+              assert.equal(files[1].name, "images/circle.png");
+              assert.equal(files[2].name, "images/my-image.bmp");
+              assert.equal(files[0].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fhome.jpg?alt=media&mode=no-rc");
+              assert.equal(files[1].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fcircle.png?alt=media&mode=no-rc");
+              assert.equal(files[2].url, "https://www.googleapis.com/storage/v1/b/risemedialibrary-abc123/o/images%2Fmy-image.bmp?alt=media&mode=no-rc");
+            }
+          };
+
+          folder.displayid = "def456";
+          folder.addEventListener("rise-storage-response", listener);
+          folder._handleStorageFolder(images);
+
+          assert.isTrue(responded);
+          done();
+        });
+
+        test("should return the correct URLs for files in a folder running in preview", function(done) {
           var files = [];
 
           listener = function(response) {
@@ -411,6 +474,8 @@
             }
           };
 
+          folder._reset();
+          folder.displayid = "preview";
           folder.addEventListener("rise-storage-response", listener);
           folder._handleStorageFolder(images);
 
@@ -640,11 +705,28 @@
 
       suite("_getSingleFileURL", function() {
 
-        test("should return the storage url of the file in a bucket", function() {
+        teardown(function() {
+          fileBucket.displayid = "";
+          fileFolder.displayid = "";
+        });
+
+        test("should return the storage url of the file in a bucket running in player", function() {
+          fileBucket.displayid = "def456";
+          assert.equal(fileBucket._getSingleFileURL(), "https://storage.googleapis.com/risemedialibrary-abc123%2Fhome.jpg?mode=no-rc");
+        });
+
+        test("should return the storage url of the file in a bucket running in preview", function() {
+          fileBucket.displayid = "preview";
           assert.equal(fileBucket._getSingleFileURL(), "https://storage.googleapis.com/risemedialibrary-abc123%2Fhome.jpg?mode=preview");
         });
 
-        test("should return the storage url of the file in a folder", function() {
+        test("should return the storage url of the file in a folder running in player", function() {
+          fileFolder.displayid = "def456";
+          assert.equal(fileFolder._getSingleFileURL(), "https://storage.googleapis.com/risemedialibrary-abc123%2Fimages%2Fhome.jpg?mode=no-rc");
+        });
+
+        test("should return the storage url of the file in a folder running in preview", function() {
+          fileFolder.displayid = "preview";
           assert.equal(fileFolder._getSingleFileURL(), "https://storage.googleapis.com/risemedialibrary-abc123%2Fimages%2Fhome.jpg?mode=preview");
         });
 


### PR DESCRIPTION
- Added `displayid` property which can be provided by Widget
- Conditionally apply "no-rc" or "preview" as value for `mode` param based on `displayid` value
- Unit and integration tests revised and added
- Feature version bump