### PR TITLE
Fixing params in "rise-cache-not-running" event

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-storage",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "authors": [
     "Rise Vision"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-storage",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Rise Vision web component for retrieving files from Rise Storage",
   "scripts": {
     "test": "gulp test",

--- a/rise-storage.html
+++ b/rise-storage.html
@@ -77,7 +77,7 @@ To specify a direction, the `sortDirection` attribute should be used. `sortDirec
 </dom-module>
 
 <!-- build:version -->
-<script>var sheetVersion = "1.4.0";</script>
+<script>var sheetVersion = "1.4.1";</script>
 <!-- endbuild -->
 
 <script>
@@ -1279,7 +1279,7 @@ To specify a direction, the `sortDirection` attribute should be used. `sortDirec
         this._pingReceived = true;
         this._totalPingRequests = 0;
 
-        this.fire("rise-cache-not-running", resp, isPlayerRunning);
+        this.fire("rise-cache-not-running", { resp: resp, isPlayerRunning: isPlayerRunning } );
 
         console.log("[rise-storage v2] Rise Cache V2 not running");
 

--- a/rise-storage.html
+++ b/rise-storage.html
@@ -77,7 +77,7 @@ To specify a direction, the `sortDirection` attribute should be used. `sortDirec
 </dom-module>
 
 <!-- build:version -->
-<script>var sheetVersion = "1.4.1";</script>
+<script>var sheetVersion = "1.4.2";</script>
 <!-- endbuild -->
 
 <script>

--- a/test/unit/rise-cache.html
+++ b/test/unit/rise-cache.html
@@ -596,9 +596,13 @@
       });
 
       test("should fire 'rise-cache-not-running` event with correct params", function(done) {
-        var listener = function() {
-          responded = true;
+        var listener = function(response) {
           cacheFile.removeEventListener("rise-cache-not-running", listener);
+
+          assert.isTrue(response.detail.isPlayerRunning);
+          assert.deepEqual(response.detail.resp, resp);
+
+          done();
         };
 
         cacheFile.addEventListener("rise-cache-not-running", listener);
@@ -607,9 +611,6 @@
         assert.equal(cacheFile._isCacheRunning, false);
         assert.equal(cacheFile._pingReceived, true);
         assert.equal(cacheFile._totalPingRequests, 0);
-        assert.isTrue(responded);
-
-        done();
       });
 
       test("should not execute go() if running in player", function() {


### PR DESCRIPTION
- Multiple params need to be provided in an object
- Revised unit test
- Minor patch version bump