### PR TITLE
Use latest rise-logger to fix RC url protocols

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "iron-ajax": "PolymerElements/iron-ajax#^1.0.0",
     "polymer": "Polymer/polymer#^1.0.0",
-    "rise-logger": "https://github.com/Rise-Vision/rise-logger.git#1.0.0",
+    "rise-logger": "https://github.com/Rise-Vision/rise-logger.git#1.0.4",
     "underscore": "~1.8.3"
   },
   "devDependencies": {

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-storage",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "authors": [
     "Rise Vision"
   ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-storage",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "Rise Vision web component for retrieving files from Rise Storage",
   "scripts": {
     "test": "gulp test",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "colors": "~1.1.0",
     "del": "~1.1.1",
     "eslint": "^3.8.1",
-    "eslint-config-idiomatic": "^2.1.0",
+    "eslint-config-idiomatic": "3.0.0",
     "eslint-plugin-html": "^1.6.0",
     "gulp": "~3.8.10",
     "gulp-bower": "~0.0.10",

--- a/rise-storage.html
+++ b/rise-storage.html
@@ -77,7 +77,7 @@ To specify a direction, the `sortDirection` attribute should be used. `sortDirec
 </dom-module>
 
 <!-- build:version -->
-<script>var sheetVersion = "1.4.4";</script>
+<script>var sheetVersion = "1.4.5";</script>
 <!-- endbuild -->
 
 <script>


### PR DESCRIPTION
- Latest release of rise-logger uses http:// as protocol instead of relative