### PR TITLE
Continue retrieving files on subscription error if RC is running

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-storage",
-  "version": "1.4.5",
+  "version": "1.5.0",
   "authors": [
     "Rise Vision"
   ],

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -30,7 +30,7 @@
       .pipe( htmlreplace( {
         "version": {
           src: pkg.version,
-          tpl: "<script>var sheetVersion = \"%s\";</script>"
+          tpl: "<script>var storageVersion = \"%s\";</script>"
         }
       }, { keepBlockTags: true } ) )
       .pipe( gulp.dest( "./" ) );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rise-storage",
-  "version": "1.4.5",
+  "version": "1.5.0",
   "description": "Rise Vision web component for retrieving files from Rise Storage",
   "scripts": {
     "test": "gulp test",

--- a/rise-storage.html
+++ b/rise-storage.html
@@ -77,7 +77,7 @@ To specify a direction, the `sortDirection` attribute should be used. `sortDirec
 </dom-module>
 
 <!-- build:version -->
-<script>var sheetVersion = "1.4.5";</script>
+<script>var sheetVersion = "1.5.0";</script>
 <!-- endbuild -->
 
 <script>
@@ -176,6 +176,13 @@ To specify a direction, the `sortDirection` attribute should be used. `sortDirec
         env: {
           type: String,
           value: "prod"
+        },
+        /**
+         * An optional attribute for Rise Player online/offline state.
+         */
+        playeroffline: {
+          type: Boolean,
+          value: false
         }
       },
 
@@ -595,8 +602,13 @@ To specify a direction, the `sortDirection` attribute should be used. `sortDirec
       },
 
       _handleStorageSubscriptionError: function( e, resp ) {
-        this.fire( "rise-storage-subscription-error", resp );
-        this._startTimer();
+        if ( this._isPlayerRunning() && this.playeroffline ) {
+          this._setSubscriptionStatus( true );
+          this._makeStorageRequest();
+        } else {
+          this.fire( "rise-storage-subscription-error", resp );
+          this._startTimer();
+        }
       },
 
       /**

--- a/rise-storage.html
+++ b/rise-storage.html
@@ -176,13 +176,6 @@ To specify a direction, the `sortDirection` attribute should be used. `sortDirec
         env: {
           type: String,
           value: "prod"
-        },
-        /**
-         * An optional attribute for Rise Player online/offline state.
-         */
-        playeroffline: {
-          type: Boolean,
-          value: false
         }
       },
 
@@ -602,11 +595,13 @@ To specify a direction, the `sortDirection` attribute should be used. `sortDirec
       },
 
       _handleStorageSubscriptionError: function( e, resp ) {
-        if ( this._isPlayerRunning() && this.playeroffline ) {
+        this.fire( "rise-storage-subscription-error", resp );
+
+        if ( this._isCacheRunning ) {
+          // proceed as if authorized to continue retrieving file(s)
           this._setSubscriptionStatus( true );
           this._makeStorageRequest();
         } else {
-          this.fire( "rise-storage-subscription-error", resp );
           this._startTimer();
         }
       },

--- a/rise-storage.html
+++ b/rise-storage.html
@@ -77,12 +77,12 @@ To specify a direction, the `sortDirection` attribute should be used. `sortDirec
 </dom-module>
 
 <!-- build:version -->
-<script>var sheetVersion = "1.5.0";</script>
+<script>var storageVersion = "1.5.0";</script>
 <!-- endbuild -->
 
 <script>
   ( function() {
-    /* global Polymer, _, sheetVersion */
+    /* global Polymer, _, storageVersion */
 
     "use strict";
 
@@ -459,7 +459,7 @@ To specify a direction, the `sortDirection` attribute should be used. `sortDirec
           params.usage_type = this.usage;
         }
 
-        params.version = sheetVersion;
+        params.version = storageVersion;
 
         // log usage
         this.$.logger.log( BQ_TABLE_NAME, params );

--- a/rise-storage.html
+++ b/rise-storage.html
@@ -598,8 +598,7 @@ To specify a direction, the `sortDirection` attribute should be used. `sortDirec
         this.fire( "rise-storage-subscription-error", resp );
 
         if ( this._isCacheRunning ) {
-          // proceed as if authorized to continue retrieving file(s)
-          this._setSubscriptionStatus( true );
+          // proceed to try and retrieve file(s)
           this._makeStorageRequest();
         } else {
           this._startTimer();

--- a/test/unit/rise-cache.html
+++ b/test/unit/rise-cache.html
@@ -650,6 +650,10 @@
         cacheFolder.displayid = "";
       } );
 
+      suiteSetup( function() {
+        cacheFile._isCacheRunning = true;
+      } );
+
       test( "should correctly set refresh interval", function() {
         cacheFolder.refresh = 10;
         cacheFolder._startTimer();
@@ -787,6 +791,38 @@
         assert( spy.calledWith( cacheFolder._folderFilesToRequest[ 0 ] ) );
 
       } );
+    } );
+
+    suite( "_handleStorageSubscriptionError", function() {
+
+      suiteSetup( function() {
+        cacheFile._isCacheRunning = true;
+      } );
+
+      test( "should fire rise-storage-subscription-error and continue with request for files", function( done ) {
+        var requestStub = sinon.stub( cacheFile, "_makeStorageRequest" ),
+          responded = false,
+          response = {
+            "xhr": {
+              "status": 404,
+              "statusText": "An error occurred"
+            }
+          },
+          listener = function() {
+            responded = true;
+            cacheFile.removeEventListener( "rise-storage-subscription-error", listener );
+          };
+
+        cacheFile.addEventListener( "rise-storage-subscription-error", listener );
+        cacheFile._handleStorageSubscriptionError( {}, response );
+
+        assert.isTrue( responded );
+        assert( requestStub.calledOnce );
+
+        cacheFile._makeStorageRequest.restore();
+        done();
+      } );
+
     } );
 
   } );

--- a/test/unit/rise-storage-subscription.html
+++ b/test/unit/rise-storage-subscription.html
@@ -16,7 +16,7 @@
 
 <script src="../js/rise-storage-data.js"></script>
 <script>
-  /* global sinon, suite, suiteSetup, suiteTeardown, setup, teardown, test, assert, xhr, clock, requests */
+  /* global sinon, suite, suiteSetup, suiteTeardown, setup, test, assert, xhr, clock, requests */
 
   var fileBucket = document.querySelector( "#file-bucket" ),
     fileBucketTest = document.querySelector( "#file-bucket-test" ),
@@ -53,12 +53,6 @@
     } );
 
     suite( "_computeStorageUrl", function() {
-
-      teardown( function() {
-        fileBucket.displayid = "";
-        fileBucket.playeroffline = false;
-      } );
-
       test( "should correctly set Store request URL", function() {
         fileBucket._getStorageSubscription();
         assert.equal( fileBucket.$.storageSubscription.url, "https://store-dot-rvaserver2.appspot.com/v1/widget/auth?cid=abc123&pc=b0cba08a4baa0c62b8cdc621b6f6a124f89a03db" );
@@ -127,32 +121,6 @@
         assert.isTrue( responded );
 
         fileBucket._startTimer.restore();
-        done();
-      } );
-
-      test( "should not fire rise-storage-subscription-error if running in player and offline", function( done ) {
-        var requestStub = sinon.stub( fileBucket, "_makeStorageRequest" ),
-          responded = false,
-          response = {
-            "xhr": {
-              "status": 404,
-              "statusText": "An error occurred"
-            }
-          },
-          listener = function() {
-            responded = true;
-            fileBucket.removeEventListener( "rise-storage-subscription-error", listener );
-          };
-
-        fileBucket.displayid = "abc123";
-        fileBucket.playeroffline = true;
-        fileBucket.addEventListener( "rise-storage-subscription-error", listener );
-        fileBucket._handleStorageSubscriptionError( {}, response );
-
-        assert( requestStub.calledOnce );
-        assert.isFalse( responded );
-
-        fileBucket._makeStorageRequest.restore();
         done();
       } );
     } );

--- a/test/unit/rise-storage-subscription.html
+++ b/test/unit/rise-storage-subscription.html
@@ -16,7 +16,7 @@
 
 <script src="../js/rise-storage-data.js"></script>
 <script>
-  /* global sinon, suite, suiteSetup, suiteTeardown, setup, test, assert, xhr, clock, requests */
+  /* global sinon, suite, suiteSetup, suiteTeardown, setup, teardown, test, assert, xhr, clock, requests */
 
   var fileBucket = document.querySelector( "#file-bucket" ),
     fileBucketTest = document.querySelector( "#file-bucket-test" ),

--- a/test/unit/rise-storage-subscription.html
+++ b/test/unit/rise-storage-subscription.html
@@ -53,6 +53,12 @@
     } );
 
     suite( "_computeStorageUrl", function() {
+
+      teardown( function() {
+        fileBucket.displayid = "";
+        fileBucket.playeroffline = false;
+      } );
+
       test( "should correctly set Store request URL", function() {
         fileBucket._getStorageSubscription();
         assert.equal( fileBucket.$.storageSubscription.url, "https://store-dot-rvaserver2.appspot.com/v1/widget/auth?cid=abc123&pc=b0cba08a4baa0c62b8cdc621b6f6a124f89a03db" );
@@ -121,6 +127,32 @@
         assert.isTrue( responded );
 
         fileBucket._startTimer.restore();
+        done();
+      } );
+
+      test( "should not fire rise-storage-subscription-error if running in player and offline", function( done ) {
+        var requestStub = sinon.stub( fileBucket, "_makeStorageRequest" ),
+          responded = false,
+          response = {
+            "xhr": {
+              "status": 404,
+              "statusText": "An error occurred"
+            }
+          },
+          listener = function() {
+            responded = true;
+            fileBucket.removeEventListener( "rise-storage-subscription-error", listener );
+          };
+
+        fileBucket.displayid = "abc123";
+        fileBucket.playeroffline = true;
+        fileBucket.addEventListener( "rise-storage-subscription-error", listener );
+        fileBucket._handleStorageSubscriptionError( {}, response );
+
+        assert( requestStub.calledOnce );
+        assert.isFalse( responded );
+
+        fileBucket._makeStorageRequest.restore();
         done();
       } );
     } );


### PR DESCRIPTION
- When a storage subscription request fails and RC is running, the component will still fire "rise-storage-subscription-error" event but also proceed with retrieving possible cached files
- Unit test added
- Feature version bump